### PR TITLE
Support uppercase constants

### DIFF
--- a/src/Enum.php
+++ b/src/Enum.php
@@ -84,6 +84,11 @@ abstract class Enum
     public static function getDescription($value): string
     {
         $key = self::getKey($value);
+        
+        if (ctype_upper($key)) {
+            $key = strtolower($key);
+        }
+        
         return ucfirst(str_replace('_', ' ', snake_case($key)));
     }
 

--- a/tests/EnumTest.php
+++ b/tests/EnumTest.php
@@ -49,6 +49,7 @@ class EnumTest extends TestCase
         $this->assertEquals('Super administrator', UserType::getDescription(3));
         $this->assertEquals('Four word key name', UserType::getDescription(4));
         $this->assertEquals('String key', UserType::getDescription('StringValue'));
+        $this->assertEquals('Uppercase', UserType::getDescription(5));
     }
 
     public function test_enum_get_random_key()

--- a/tests/EnumTest.php
+++ b/tests/EnumTest.php
@@ -16,7 +16,7 @@ class EnumTest extends TestCase
     public function test_enum_get_keys()
     {
         $keys = UserType::getKeys();
-        $expectedKeys = ['Administrator', 'Moderator', 'Subscriber', 'SuperAdministrator', 'FourWordKeyName', 'StringKey'];
+        $expectedKeys = ['Administrator', 'Moderator', 'Subscriber', 'SuperAdministrator', 'FourWordKeyName', 'UPPERCASE', 'StringKey'];
 
         $this->assertEquals($expectedKeys, $keys);
     }
@@ -24,7 +24,7 @@ class EnumTest extends TestCase
     public function test_enum_get_values()
     {
         $values = UserType::getValues();
-        $expectedValues = [0, 1, 2, 3, 4, 'StringValue'];
+        $expectedValues = [0, 1, 2, 3, 4, 5, 'StringValue'];
 
         $this->assertEquals($expectedValues, $values);
     }
@@ -71,6 +71,7 @@ class EnumTest extends TestCase
             'Subscriber' => 2,
             'SuperAdministrator' => 3,
             'FourWordKeyName' => 4,
+            'UPPERCASE' => 5,
             'StringKey' => 'StringValue',
         ];
 
@@ -86,6 +87,7 @@ class EnumTest extends TestCase
             2 => 'Subscriber',
             3 => 'Super administrator',
             4 => 'Four word key name',
+            5 => 'Uppercase',
             'StringValue' => 'String key',
         ];
 

--- a/tests/UserType.php
+++ b/tests/UserType.php
@@ -11,5 +11,6 @@ final class UserType extends Enum
     const Subscriber = 2;
     const SuperAdministrator = 3;
     const FourWordKeyName = 4;
+    const UPPERCASE = 5;
     const StringKey = 'StringValue';
 }


### PR DESCRIPTION
For some obscure reason a lot of developers (including me) resort to uppercasing all constants:

```php
final class Foo extends Enum {
    const ONE = 1;
    const TWO = 2;
}
```

Currently the auto generated description yields superfluous spaces because of the `snake_case` call:
```
o n e
t w o
```

This PR just adds a simple check.