### PR TITLE
Add validation localization

### DIFF
--- a/src/EnumServiceProvider.php
+++ b/src/EnumServiceProvider.php
@@ -17,6 +17,11 @@ class EnumServiceProvider extends ServiceProvider
                 MakeEnumCommand::class,
             ]);
         }
+
+        $this->loadTranslationsFrom(
+            __DIR__ . '/lang',
+            'laravel-enum'
+        );
     }
 
     /**

--- a/src/Rules/EnumKey.php
+++ b/src/Rules/EnumKey.php
@@ -40,6 +40,6 @@ class EnumKey implements Rule
      */
     public function message()
     {
-        return 'The key you have entered is invalid.';
+        return trans('laravel-enum::validation.enum_key');
     }
 }

--- a/src/Rules/EnumValue.php
+++ b/src/Rules/EnumValue.php
@@ -42,6 +42,6 @@ class EnumValue implements Rule
      */
     public function message()
     {
-        return 'The value you have entered is invalid.';
+        return trans('laravel-enum::validation.enum_value');
     }
 }

--- a/src/lang/en/validation.php
+++ b/src/lang/en/validation.php
@@ -1,0 +1,6 @@
+<?php
+
+return [
+    'enum_key' => 'The key you have entered is invalid.',
+    'enum_value' => 'The value you have entered is invalid.',
+];

--- a/src/lang/zh-CN/validation.php
+++ b/src/lang/zh-CN/validation.php
@@ -1,0 +1,6 @@
+<?php
+
+return [
+    'enum_key' => '枚举键名无效。',
+    'enum_value' => '枚举键值无效。',
+];


### PR DESCRIPTION
Before this, all validation messages were hard-coded. When I wanna translate it to another language, I have to extend `EnumKey` or `EnumValue` class and override `message` method.

Now I change it to use language resource, which means add `enum_key` or `enum_value` to `resources/lang/xx/validation.php` is the only thing you should do when translating validation messages into other languages.

For contributors, we can add more built-in language files.

My English is bad, but I'm trying my best.