### PR TITLE
Fix #31

### DIFF
--- a/src/Enum.php
+++ b/src/Enum.php
@@ -86,7 +86,7 @@ abstract class Enum
     public static function getDescription($value): string
     {
         return 
-            self::getLocalizedDescription($value) ??
+            self::getLocalizedDescription($value) ?:
             self::getFriendlyKeyName(self::getKey($value));
     }
 
@@ -97,7 +97,7 @@ abstract class Enum
      * @param int|string $value
      * @return string
      */
-    private static function getLocalizedDescription($value): ?string
+    private static function getLocalizedDescription($value): string
     {
         if (self::isLocalizable())
         {
@@ -109,7 +109,7 @@ abstract class Enum
             }
         }
 
-        return null;
+        return '';
     }
 
     /**


### PR DESCRIPTION
As [the issue](https://github.com/BenSampo/laravel-enum/issues/31) is pointing out, `nullable return type` isn't supported until php7.1, it conflicts with the requirement of the package (php7.0).
So, it's just easy to update the requirement to php7.1.
But I tried to fix the issue by keeping the requirement as it is. 
@BenSampo It's your call to make the choice. :) 