### PR TITLE
Test against php 7.2 and 7.3 too

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,23 @@
+dist: xenial
+
 language: php
 
-cache:
-  directories:
-  - "$HOME/.composer/cache"
+php:
+- 7.1
+- 7.2
+- 7.3
 
-matrix:
-  include:
-  - php: 7.1
-    env: LARAVEL=5.4
+env:
+  matrix:
+  - COMPOSER_FLAGS="--prefer-lowest"
+  - COMPOSER_FLAGS=""
+
+install:
+- travis_retry composer update ${COMPOSER_FLAGS} --no-interaction --no-suggest
 
 script:
 - vendor/bin/phpunit -c phpunit.xml tests/
 
-install: composer install --no-interaction
+cache:
+  directories:
+    - $HOME/.composer/cache


### PR DESCRIPTION
Hi,
Thanks for awesome library.

I noticed we are not testing this library against most recent versions of php.

This PR makes it possible to test against multiple versions.
This is the most recommended way to cover majority of users.
Read more here:
https://evertpot.com/testing-composer-prefer-lowest/

You can see how it goes on TravisCI
https://travis-ci.org/BenSampo/laravel-enum/builds/494119222

Thanks.
