### PR TITLE
Enum Instance Support

### DIFF
--- a/src/Enum.php
+++ b/src/Enum.php
@@ -85,13 +85,13 @@ abstract class Enum
      */
     public static function getDescription($value): string
     {
-        return 
+        return
             static::getLocalizedDescription($value) ??
             static::getFriendlyKeyName(static::getKey($value));
     }
 
     /**
-     * Get the localized description if localization is enabled 
+     * Get the localized description if localization is enabled
      * for the enum and if they key exists in the lang file
      *
      * @param int|string $value

--- a/src/EnumInstanceTrait.php
+++ b/src/EnumInstanceTrait.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace BenSampo\Enum;
+
+trait EnumInstanceTrait
+{
+
+    /**
+     * The value of one the enum constants.
+     *
+     * @var mixed
+     */
+    protected $value;
+
+    /**
+     * The constructor needs to be hidden so that an enum
+     * instance can't created with invalid values
+     *
+     * @param mixed $value
+     */
+    protected function __construct($value)
+    {
+        $this->value = $value;
+    }
+
+    /**
+     * Checks the equality of the value against the enum instance.
+     *
+     * @param mixed $value
+     * @return void
+     */
+    public function equals($value)
+    {
+        static::validateValue($value);
+        return $this->value === $value;
+    }
+
+    /**
+     * Return an enum instance so that it can be used as
+     * typehint on methods, functions or constructors.
+     *
+     * @param mixed $value
+     * @return self
+     */
+    public static function getInstance($value): self
+    {
+        static::validateValue($value);
+        return new self($value);
+    }
+
+
+    /**
+     * Validates that the given value exists in the constants
+     * definition/list.
+     *
+     * @param mixed $value
+     * @throws InvalidArgumentException
+     */
+    protected static function validateValue($value)
+    {
+        if (!static::hasValue($value)) {
+            $values = implode(', ', static::getValues());
+            throw new \InvalidArgumentException("Value {$value} doesn't exist in [{$values}]");
+        }
+    }
+}

--- a/src/Stubs/Enum.stub
+++ b/src/Stubs/Enum.stub
@@ -3,9 +3,12 @@
 namespace DummyNamespace;
 
 use BenSampo\Enum\Enum;
+use BenSampo\Enum\EnumInstanceTrait;
 
 final class DummyClass extends Enum
 {
+    use EnumInstanceTrait;
+
     const OptionOne = 0;
     const OptionTwo = 1;
     const OptionThree = 2;

--- a/tests/EnumInstanceTest.php
+++ b/tests/EnumInstanceTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace BenSampo\Enum\Tests;
+
+use PHPUnit\Framework\TestCase;
+use BenSampo\Enum\Rules\EnumKey;
+use BenSampo\Enum\Tests\Enums\UserType;
+use BenSampo\Enum\Tests\Enums\StringValues;
+use BenSampo\Enum\Tests\Enums\MixedKeyFormats;
+
+class EnumInstanceTest extends TestCase
+{
+    public function testPasses()
+    {
+        $userType = UserType::getInstance(UserType::Administrator);
+
+        $this->assertInstanceOf(UserType::class, $userType);
+        $this->assertTrue($userType->equals(UserType::Administrator));
+        $this->assertFalse($userType->equals(UserType::SuperAdministrator));
+    }
+
+    /**
+     * Throws an expection if the given value is invalid.
+     *
+     * @expectedException \InvalidArgumentException
+     * @return void
+     */
+    public function testFails()
+    {
+        $userType = StringValues::getInstance(UserType::Subscriber);
+        $stringType = StringValues::getInstance(StringValues::Administrator);
+
+        $stringType->equals(MixedKeyFormats::Normal);
+    }
+
+
+    /**
+     * Throws an expection if the given value is invalid.
+     *
+     * @expectedException \InvalidArgumentException
+     * @return void
+     */
+    public function testExpectExceptionOnEqualityCheck()
+    {
+        $stringType = StringValues::getInstance(StringValues::Administrator);
+        $stringType->equals(MixedKeyFormats::Normal);
+    }
+}

--- a/tests/Enums/MixedKeyFormats.php
+++ b/tests/Enums/MixedKeyFormats.php
@@ -3,9 +3,12 @@
 namespace BenSampo\Enum\Tests\Enums;
 
 use BenSampo\Enum\Enum;
+use BenSampo\Enum\EnumInstanceTrait;
 
 final class MixedKeyFormats extends Enum
 {
+    use EnumInstanceTrait;
+
     const Normal = 1;
     const MultiWordKeyName = 2;
     const UPPERCASE = 3;

--- a/tests/Enums/StringValues.php
+++ b/tests/Enums/StringValues.php
@@ -3,9 +3,12 @@
 namespace BenSampo\Enum\Tests\Enums;
 
 use BenSampo\Enum\Enum;
+use BenSampo\Enum\EnumInstanceTrait;
 
 final class StringValues extends Enum
 {
+    use EnumInstanceTrait;
+
     const Administrator = 'administrator';
     const Moderator = 'moderator';
 }

--- a/tests/Enums/UserType.php
+++ b/tests/Enums/UserType.php
@@ -3,9 +3,12 @@
 namespace BenSampo\Enum\Tests\Enums;
 
 use BenSampo\Enum\Enum;
+use BenSampo\Enum\EnumInstanceTrait;
 
 final class UserType extends Enum
 {
+    use EnumInstanceTrait;
+
     const Administrator = 0;
     const Moderator = 1;
     const Subscriber = 2;

--- a/tests/Enums/UserTypeLocalized.php
+++ b/tests/Enums/UserTypeLocalized.php
@@ -4,9 +4,12 @@ namespace BenSampo\Enum\Tests\Enums;
 
 use BenSampo\Enum\Enum;
 use BenSampo\Enum\Contracts\LocalizedEnum;
+use BenSampo\Enum\EnumInstanceTrait;
 
 final class UserTypeLocalized extends Enum implements LocalizedEnum
 {
+    use EnumInstanceTrait;
+
     const Moderator = 0;
     const Administrator = 1;
     const SuperAdministrator = 2;


### PR DESCRIPTION
The reason for this pull request is to allow instances of enum which
allows less error since one can typehint a method, constructor and function
to accept only an instance of that enum.

Since the enums contains only literal which can be easily bypassed by
passing the actual value of the constant.

```php

$userType = UserType::getInstance(UserType::Administrator);

// This way one is rest assured that the
// user's type is from the UserType enum.
createUser(array $data, UserType $userType)
{
    if ($userType->equals(UserType::Administrator)) {
        // ...;
    } else {
        // ...;
    }
}
```