### PR TITLE
Remove trait from stub

### DIFF
--- a/src/Stubs/Enum.stub
+++ b/src/Stubs/Enum.stub
@@ -3,12 +3,9 @@
 namespace DummyNamespace;
 
 use BenSampo\Enum\Enum;
-use BenSampo\Enum\EnumInstanceTrait;
 
 final class DummyClass extends Enum
 {
-    use EnumInstanceTrait;
-
     const OptionOne = 0;
     const OptionTwo = 1;
     const OptionThree = 2;


### PR DESCRIPTION
Hi,

`php artisan make:enum WeekDay` is generating wrong class,
The `EnumInstanceTrait` is no longer available in package.