### PR TITLE
Exclude branding from git archive

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,3 +7,4 @@
 .travis.yml        export-ignore
 phpunit.xml        export-ignore
 /tests             export-ignore
+/branding             export-ignore


### PR DESCRIPTION
Hi,

We can exclude `branding` folder, it will reduce the package size.