### PR TITLE
Specify the Laravel version up to minor explicitely

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "illuminate/support": "~5.4",
+        "illuminate/support": "5.4.*|5.5.*|5.6.*|5.7.*|5.8.*",
         "php" : "~7.1"
     },
     "require-dev": {


### PR DESCRIPTION
This is necessary because Laravel does not use Semantic Versioning, so minor version updates can have breaking changes.