### PR TITLE
Fix type hints and docblocks to Laravel style

### DIFF
--- a/src/Commands/MakeEnumCommand.php
+++ b/src/Commands/MakeEnumCommand.php
@@ -40,8 +40,7 @@ class MakeEnumCommand extends GeneratorCommand
     /**
      * Get the default namespace for the class.
      *
-     * @param string $rootNamespace
-     *
+     * @param  string  $rootNamespace
      * @return string
      */
     protected function getDefaultNamespace($rootNamespace)

--- a/src/Contracts/EnumContract.php
+++ b/src/Contracts/EnumContract.php
@@ -4,5 +4,11 @@ namespace BenSampo\Enum\Contracts;
 
 interface EnumContract
 {
+    /**
+     * Determine if this instance is equivalent to a given value.
+     *
+     * @param  mixed  $enumValue
+     * @return bool
+     */
     public function is($enumValue): bool;
 }

--- a/src/Contracts/LocalizedEnum.php
+++ b/src/Contracts/LocalizedEnum.php
@@ -4,5 +4,10 @@ namespace BenSampo\Enum\Contracts;
 
 interface LocalizedEnum
 {
+    /**
+     * Get the default localization key.
+     *
+     * @return string
+     */
     public static function getLocalizationKey();
 }

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -17,38 +17,38 @@ abstract class Enum implements EnumContract
     }
 
     /**
-     * The key of one the enum members.
+     * The key of one of the enum members.
      *
      * @var mixed
      */
     public $key;
 
     /**
-     * The value of one the enum members.
+     * The value of one of the enum members.
      *
      * @var mixed
      */
     public $value;
 
     /**
-     * The description of one the enum members.
+     * The description of one of the enum members.
      *
      * @var mixed
      */
     public $description;
 
     /**
-     * Constants cache
+     * Constants cache.
      *
      * @var array
      */
     protected static $constCacheArray = [];
 
     /**
-     * Return an enum instance
+     * Construct an Enum instance.
      *
-     * @param mixed $enumValue
-     * @return EnumContract
+     * @param  mixed  $enumValue
+     * @return void
      */
     public function __construct($enumValue)
     {
@@ -63,10 +63,11 @@ abstract class Enum implements EnumContract
 
     /**
      * Attempt to instantiate an enum by calling the enum key as a static method.
+     *
      * This function defers to the macroable __callStatic function if a macro is found using the static method called.
      *
-     * @param string $method
-     * @param mixed $parameters
+     * @param  string  $method
+     * @param  mixed  $parameters
      * @return mixed
      */
     public static function __callStatic($method, $parameters)
@@ -87,7 +88,7 @@ abstract class Enum implements EnumContract
     /**
      * Checks the equality of the value against the enum instance.
      *
-     * @param mixed $enumValue
+     * @param  mixed  $enumValue
      * @return bool
      */
     public function is($enumValue): bool
@@ -100,18 +101,18 @@ abstract class Enum implements EnumContract
     }
 
     /**
-     * Return an enum instance
+     * Return a new Enum instance,
      *
-     * @param mixed $enumValue
-     * @return EnumContract
+     * @param  mixed  $enumValue
+     * @return static
      */
-    public static function getInstance($enumValue): EnumContract
+    public static function getInstance($enumValue): Enum
     {
         return new static($enumValue);
     }
 
     /**
-     * Get all of the constants on the class
+     * Get all of the constants defined on the class.
      *
      * @return array
      */
@@ -128,7 +129,7 @@ abstract class Enum implements EnumContract
     }
 
     /**
-     * Get all of the enum keys
+     * Get all of the enum keys.
      *
      * @return array
      */
@@ -138,7 +139,7 @@ abstract class Enum implements EnumContract
     }
 
     /**
-     * Get all of the enum values
+     * Get all of the enum values.
      *
      * @return array
      */
@@ -148,10 +149,10 @@ abstract class Enum implements EnumContract
     }
 
     /**
-     * Get the key for a single enum value
+     * Get the key for a single enum value.
      *
-     * @param int|string $value
-     * @return int|string
+     * @param  mixed  $value
+     * @return string
      */
     public static function getKey($value): string
     {
@@ -161,8 +162,8 @@ abstract class Enum implements EnumContract
     /**
      * Get the value for a single enum key
      *
-     * @param string $key
-     * @return int|string
+     * @param  string  $key
+     * @return mixed
      */
     public static function getValue(string $key)
     {
@@ -172,7 +173,7 @@ abstract class Enum implements EnumContract
     /**
      * Get the description for an enum value
      *
-     * @param int|string $value
+     * @param  mixed  $value
      * @return string
      */
     public static function getDescription($value): string
@@ -183,11 +184,13 @@ abstract class Enum implements EnumContract
     }
 
     /**
-     * Get the localized description if localization is enabled 
-     * for the enum and if the key exists in the lang file
+     * Get the localized description of a value.
      *
-     * @param int|string $value
-     * @return string
+     * This works only if localization is enabled
+     * for the enum and if the key exists in the lang file.
+     *
+     * @param  mixed  $value
+     * @return string|null
      */
     protected static function getLocalizedDescription($value): ?string
     {
@@ -205,30 +208,33 @@ abstract class Enum implements EnumContract
     }
 
     /**
-     * Get a random key from the enum
+     * Get a random key from the enum.
      *
      * @return string
      */
     public static function getRandomKey(): string
     {
         $keys = static::getKeys();
+
         return $keys[array_rand($keys)];
     }
 
     /**
-     * Get a random value from the enum
+     * Get a random value from the enum.
      *
-     * @return int|string
+     * @return mixed
      */
     public static function getRandomValue()
     {
         $values = static::getValues();
+
         return $values[array_rand($values)];
     }
 
     /**
-     * Return the enum as an array
-     * key => value
+     * Return the enum as an array.
+     *
+     * [string $key => mixed $value]
      *
      * @return array
      */
@@ -239,7 +245,8 @@ abstract class Enum implements EnumContract
 
     /**
      * Get the enum as an array formatted for a select.
-     * value => description
+     *
+     * [mixed $value => string description]
      *
      * @return array
      */
@@ -256,9 +263,9 @@ abstract class Enum implements EnumContract
     }
 
     /**
-     * Check that the enum contains a specific key
+     * Check that the enum contains a specific key.
      *
-     * @param string $key
+     * @param  string  $key
      * @return bool
      */
     public static function hasKey(string $key): bool
@@ -269,8 +276,8 @@ abstract class Enum implements EnumContract
     /**
      * Check that the enum contains a specific value
      *
-     * @param int|string $value
-     * @param bool $strict (Optional, defaults to True)
+     * @param  mixed  $value
+     * @param  bool  $strict (Optional, defaults to True)
      * @return bool
      */
     public static function hasValue($value, bool $strict = true): bool
@@ -285,9 +292,9 @@ abstract class Enum implements EnumContract
     }
 
     /**
-     * Transform the key name into a friendly, formatted version
+     * Transform the key name into a friendly, formatted version.
      *
-     * @param string $key
+     * @param  string  $key
      * @return string
      */
     protected static function getFriendlyKeyName(string $key): string
@@ -300,9 +307,9 @@ abstract class Enum implements EnumContract
     }
 
     /**
-     * Check that the enum implements the LocalizedEnum interface
+     * Check that the enum implements the LocalizedEnum interface.
      *
-     * @return boolean
+     * @return bool
      */
     protected static function isLocalizable(): bool
     {
@@ -310,7 +317,7 @@ abstract class Enum implements EnumContract
     }
 
     /**
-     * Get the default localization key
+     * Get the default localization key.
      *
      * @return string
      */

--- a/src/EnumServiceProvider.php
+++ b/src/EnumServiceProvider.php
@@ -12,6 +12,8 @@ class EnumServiceProvider extends ServiceProvider
 {
     /**
      * Perform post-registration booting of services.
+     *
+     * @return void
      */
     public function boot()
     {

--- a/src/Exceptions/InvalidEnumMemberException.php
+++ b/src/Exceptions/InvalidEnumMemberException.php
@@ -7,8 +7,17 @@ use BenSampo\Enum\Enum;
 
 class InvalidEnumMemberException extends Exception
 {
-    public function __construct($invalidValue, Enum $enum) {
+    /**
+     * Create an InvalidEnumMemberException.
+     *
+     * @param  mixed  $invalidValue
+     * @param  \BenSampo\Enum\Enum  $enum
+     * @return void
+     */
+    public function __construct($invalidValue, Enum $enum)
+    {
         $enumValues = implode(', ', $enum::getValues());
+
         parent::__construct("Value {$invalidValue} doesn't exist in [{$enumValues}]");
     }
 }

--- a/src/Rules/EnumKey.php
+++ b/src/Rules/EnumKey.php
@@ -6,10 +6,16 @@ use Illuminate\Contracts\Validation\Rule;
 
 class EnumKey implements Rule
 {
-    private $enumClass;
+    /**
+     * @var string|\BenSampo\Enum\Enum
+     */
+    protected $enumClass;
 
     /**
      * Create a new rule instance.
+     *
+     * @param  string  $enum
+     * @return void
      */
     public function __construct(string $enum)
     {
@@ -23,9 +29,8 @@ class EnumKey implements Rule
     /**
      * Determine if the validation rule passes.
      *
-     * @param string $attribute
-     * @param mixed  $value
-     *
+     * @param  string  $attribute
+     * @param  mixed  $value
      * @return bool
      */
     public function passes($attribute, $value)
@@ -36,7 +41,7 @@ class EnumKey implements Rule
     /**
      * Get the validation error message.
      *
-     * @return string
+     * @return string|array
      */
     public function message()
     {

--- a/src/Rules/EnumValue.php
+++ b/src/Rules/EnumValue.php
@@ -6,14 +6,26 @@ use Illuminate\Contracts\Validation\Rule;
 
 class EnumValue implements Rule
 {
-    private $enumClass;
+    /**
+     * @var string|\BenSampo\Enum\Enum
+     */
+    protected $enumClass;
+
+    /**
+     * @var bool
+     */
+    protected $strict;
 
     /**
      * Create a new rule instance.
+     *
+     * @param  string  $enumClass
+     * @param  bool  $strict
+     * @return void
      */
-    public function __construct(string $enum, bool $strict = true)
+    public function __construct(string $enumClass, bool $strict = true)
     {
-        $this->enumClass = $enum;
+        $this->enumClass = $enumClass;
         $this->strict = $strict;
 
         if (! class_exists($this->enumClass)) {
@@ -24,9 +36,8 @@ class EnumValue implements Rule
     /**
      * Determine if the validation rule passes.
      *
-     * @param string $attribute
-     * @param mixed  $value
-     *
+     * @param  string  $attribute
+     * @param  mixed  $value
      * @return bool
      */
     public function passes($attribute, $value)
@@ -37,7 +48,7 @@ class EnumValue implements Rule
     /**
      * Get the validation error message.
      *
-     * @return string
+     * @return string|array
      */
     public function message()
     {

--- a/src/Traits/CastsEnums.php
+++ b/src/Traits/CastsEnums.php
@@ -53,7 +53,7 @@ trait CastsEnums
      * @param  string  $key
      * @return bool
      */
-    public function hasEnumCast($key)
+    public function hasEnumCast($key): bool
     {
         return array_key_exists($key, $this->enumCasts);
     }
@@ -61,11 +61,13 @@ trait CastsEnums
     /**
      * Casts the given key to an enum instance
      *
-     * @param mixed $key
-     * @return Enum|null
+     * @param  string  $key
+     * @param  mixed  $value
+     * @return \BenSampo\Enum\Enum|null
      */
     protected function castToEnum($key, $value): ?Enum
     {
+        /** @var \BenSampo\Enum\Enum $enum */
         $enum = $this->enumCasts[$key];
 
         if ($value === null || $value instanceOf Enum) {


### PR DESCRIPTION
Some type hints were out of date, so i fixed them.

In the Laravel code style, Docblocks look a bit different - i adopted that here as well
to be consistent.

Thanks for a great package, it has been quite helpful!