### PR TITLE
PHPStan integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Created by [Ben Sampson](https://sampo.co.uk)
 * [Validation](#validation)
 * [Localization](#localization)
 * [Extending the Enum base class](#extending-the-enum-base-class)
+* [PHPStan Integration](#phpstan-integration)
 
 ## Guide
 I wrote a blog post about using laravel-enum:
@@ -433,3 +434,16 @@ Enum::macro('toFlippedArray', function() {
 Now, on each of my enums, I can call it using `UserType::toFlippedArray()`.
 
 It's best to register the macro inside of a service providers' boot method.
+
+## PHPStan integration
+
+If you are using [PHPStan](https://github.com/phpstan/phpstan) for static
+analysis, you can enable the extension for proper recognition of the
+magic instantiation methods.
+
+Add the following to your projects `phpstan.neon` includes:
+
+```neon
+includes:
+- vendor/bensampo/laravel-enum/extension.neon
+```

--- a/composer.json
+++ b/composer.json
@@ -23,10 +23,11 @@
         "php" : "~7.1"
     },
     "require-dev": {
-        "squizlabs/php_codesniffer": "^3.0",
-        "phpunit/phpunit": "7.5.*",
         "laravel/framework": "5.8.*",
-        "orchestra/testbench": "3.8.*"
+        "orchestra/testbench": "3.8.*",
+        "phpstan/phpstan": "^0.11.6",
+        "phpunit/phpunit": "7.5.*",
+        "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {
         "psr-4": {

--- a/extension.neon
+++ b/extension.neon
@@ -1,4 +1,4 @@
 services:
-- class: \BenSampo\Enum\PHPStan\BenSampo\Enum\EnumMethodsClassReflectionExtension
+- class: \BenSampo\Enum\PHPStan\EnumMethodsClassReflectionExtension
   tags:
   - phpstan.broker.methodsClassReflectionExtension

--- a/extension.neon
+++ b/extension.neon
@@ -1,0 +1,4 @@
+services:
+- class: \BenSampo\Enum\PHPStan\EnumMethodsClassReflection
+  tags:
+  - phpstan.broker.methodsClassReflectionExtension

--- a/extension.neon
+++ b/extension.neon
@@ -1,4 +1,4 @@
 services:
-- class: \BenSampo\Enum\PHPStan\EnumMethodsClassReflection
+- class: \BenSampo\Enum\PHPStan\BenSampo\Enum\EnumMethodsClassReflectionExtension
   tags:
   - phpstan.broker.methodsClassReflectionExtension

--- a/src/PHPStan/EnumMethodReflection.php
+++ b/src/PHPStan/EnumMethodReflection.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace BenSampo\Enum\PHPStan;
+
+use PHPStan\Reflection\ClassMemberReflection;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\FunctionVariant;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\ObjectType;
+
+class EnumMethodReflection implements MethodReflection
+{
+    /**
+     * @var \PHPStan\Reflection\ClassReflection
+     */
+    private $classReflection;
+
+    /**
+     * @var string
+     */
+    private $name;
+
+    public function __construct(ClassReflection $classReflection, string $name)
+    {
+        $this->classReflection = $classReflection;
+        $this->name = $name;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getDeclaringClass(): ClassReflection
+    {
+        return $this->classReflection;
+    }
+
+    public function isStatic(): bool
+    {
+        return true;
+    }
+
+    public function isPrivate(): bool
+    {
+        return false;
+    }
+
+    public function isPublic(): bool
+    {
+        return true;
+    }
+
+    public function getPrototype(): ClassMemberReflection
+    {
+        return $this;
+    }
+
+    public function getVariants(): array
+    {
+        return [
+            new FunctionVariant(
+                [],
+                false,
+                new ObjectType($this->classReflection->getName())
+            ),
+        ];
+    }
+}

--- a/src/PHPStan/EnumMethodsClassReflectionExtension.php
+++ b/src/PHPStan/EnumMethodsClassReflectionExtension.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace BenSampo\Enum\PHPStan;
+
+use BenSampo\Enum\Enum;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Reflection\MethodsClassReflectionExtension;
+
+class EnumMethodsClassReflectionExtension implements MethodsClassReflectionExtension
+{
+    public function hasMethod(ClassReflection $classReflection, string $methodName): bool
+    {
+        if(
+            $classReflection->isSubclassOf(Enum::class)
+            && $classReflection->hasConstant($methodName)
+        ) {
+            return true;
+        }
+
+        return false;
+    }
+
+    public function getMethod(ClassReflection $classReflection, string $methodName): MethodReflection
+    {
+        return new EnumMethodReflection($classReflection, $methodName);
+    }
+}

--- a/tests/PHPStanTest.php
+++ b/tests/PHPStanTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace BenSampo\Enum\Tests;
+
+use BenSampo\Enum\PHPStan\EnumMethodsClassReflectionExtension;
+use BenSampo\Enum\Tests\Enums\UserType;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Testing\TestCase;
+
+class PHPStanTest extends TestCase
+{
+    /**
+     * @var \BenSampo\Enum\PHPStan\EnumMethodsClassReflectionExtension
+     */
+    private $reflectionExtension;
+
+    /**
+     * @var \PHPStan\Reflection\ClassReflection
+     */
+    private $enumReflection;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $broker = $this->createBroker();
+        $this->enumReflection = $broker->getClass(UserType::class);
+
+        $this->reflectionExtension = new EnumMethodsClassReflectionExtension();
+    }
+
+    public function test_recognizes_magic_static_methods()
+    {
+        $this->assertTrue(
+            $this->reflectionExtension->hasMethod($this->enumReflection, 'Administrator')
+        );
+
+        $this->assertFalse(
+            $this->reflectionExtension->hasMethod($this->enumReflection, 'FooBar')
+        );
+    }
+
+    public function test_get_enum_method_reflection()
+    {
+        $this->assertInstanceOf(
+            MethodReflection::class,
+            $this->reflectionExtension->getMethod($this->enumReflection, 'Administrator')
+        );
+    }
+}


### PR DESCRIPTION
If you are using [PHPStan](https://github.com/phpstan/phpstan) for static
analysis, you can enable the extension for proper recognition of the
magic instantiation methods.

Add the following to your projects `phpstan.neon` includes:

```neon
includes:
- vendor/bensampo/laravel-enum/extension.neon
```
