### PR TITLE
 Add command to generate PHPDocs for magic instantiation methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,11 @@ $enumInstance = UserType::getInstance(UserType::Administrator);
 $enumInstance = UserType::Administrator();
 ```
 
+If you want your IDE to autocomplete the static instantiation helpers, you can
+generate PHPDoc annotations through an artisan command.
+
+    php artisan enum:annotate "App\Enums\UserType"
+
 ### Instance Properties
 
 Once you have an enum instance, you can access the `key`, `value` and `description` as properties. This is particularly useful if you're passing an enum instance to a blade view.

--- a/src/Commands/EnumAnnotateCommand.php
+++ b/src/Commands/EnumAnnotateCommand.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace BenSampo\Enum\Commands;
+
+use ReflectionClass;
+use BenSampo\Enum\Enum;
+use Illuminate\Console\Command;
+use Illuminate\Contracts\Filesystem\Filesystem;
+use Symfony\Component\Console\Input\InputArgument;
+
+class EnumAnnotateCommand extends Command
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'enum:annotate';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Generate annotations for an enum class';
+
+    /**
+     * @var \Illuminate\Contracts\Filesystem\Filesystem
+     */
+    protected $filesystem;
+
+    /**
+     * @param  \Illuminate\Contracts\Filesystem\Filesystem  $filesystem
+     * @return void
+     */
+    public function __construct(Filesystem $filesystem)
+    {
+        parent::__construct();
+
+        $this->filesystem = $filesystem;
+    }
+
+    protected function getArguments()
+    {
+        return [
+            ['class', InputArgument::REQUIRED, 'The class name to generate annotations for']
+        ];
+    }
+
+    /**
+     * Handle the command call.
+     *
+     * @return void
+     * @throws \ReflectionException
+     */
+    public function handle()
+    {
+        $className = $this->argument('class');
+
+        if(! is_subclass_of($className, Enum::class)){
+            $this->error("The given class must be an instance of BenSampo\Enum\Enum: $className.");
+            return;
+        }
+
+        $reflection = new ReflectionClass($className);
+
+        $docBlock = "/**\n";
+        foreach($reflection->getConstants() as $name => $value) {
+            $docBlock .= " * @method static static {$name}\n";
+        }
+        $docBlock .= " */\n";
+
+        $shortName = $reflection->getShortName();
+        $fileName = $reflection->getFileName();
+        $contents = $this->filesystem->get($fileName);
+
+        $classDeclaration = "class {$shortName}";
+        $classDeclarationOffset = strpos($contents, $classDeclaration);
+        // Make sure we don't replace too much
+        $contents = substr_replace(
+            $contents,
+            "{$docBlock}\nclass {$shortName}",
+            $classDeclarationOffset,
+            strlen($classDeclaration)
+        );
+
+        $this->filesystem->put($fileName, $contents);
+        $this->info("Wrote new phpDocBlock to {$fileName}.");
+    }
+}

--- a/src/Commands/EnumAnnotateCommand.php
+++ b/src/Commands/EnumAnnotateCommand.php
@@ -5,7 +5,7 @@ namespace BenSampo\Enum\Commands;
 use ReflectionClass;
 use BenSampo\Enum\Enum;
 use Illuminate\Console\Command;
-use Illuminate\Contracts\Filesystem\Filesystem;
+use \Illuminate\Filesystem\Filesystem;
 use Symfony\Component\Console\Input\InputArgument;
 
 class EnumAnnotateCommand extends Command
@@ -25,12 +25,12 @@ class EnumAnnotateCommand extends Command
     protected $description = 'Generate annotations for an enum class';
 
     /**
-     * @var \Illuminate\Contracts\Filesystem\Filesystem
+     * @var \Illuminate\Filesystem\Filesystem
      */
     protected $filesystem;
 
     /**
-     * @param  \Illuminate\Contracts\Filesystem\Filesystem  $filesystem
+     * @param  \Illuminate\Filesystem\Filesystem  $filesystem
      * @return void
      */
     public function __construct(Filesystem $filesystem)
@@ -71,15 +71,22 @@ class EnumAnnotateCommand extends Command
         $docBlock .= " */\n";
 
         $shortName = $reflection->getShortName();
-        $fileName = '/' . $reflection->getFileName();
+        $fileName = $reflection->getFileName();
         $contents = $this->filesystem->get($fileName);
 
         $classDeclaration = "class {$shortName}";
+
+        if($reflection->isFinal()){
+            $classDeclaration = "final {$classDeclaration}";
+        } elseif($reflection->isAbstract()){
+            $classDeclaration = "abstract {$classDeclaration}";
+        }
+
         $classDeclarationOffset = strpos($contents, $classDeclaration);
         // Make sure we don't replace too much
         $contents = substr_replace(
             $contents,
-            "{$docBlock}\nclass {$shortName}",
+            $docBlock . $classDeclaration,
             $classDeclarationOffset,
             strlen($classDeclaration)
         );

--- a/src/Commands/EnumAnnotateCommand.php
+++ b/src/Commands/EnumAnnotateCommand.php
@@ -71,7 +71,7 @@ class EnumAnnotateCommand extends Command
         $docBlock .= " */\n";
 
         $shortName = $reflection->getShortName();
-        $fileName = $reflection->getFileName();
+        $fileName = '/' . $reflection->getFileName();
         $contents = $this->filesystem->get($fileName);
 
         $classDeclaration = "class {$shortName}";

--- a/src/EnumServiceProvider.php
+++ b/src/EnumServiceProvider.php
@@ -7,6 +7,7 @@ use BenSampo\Enum\Rules\EnumValue;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Facades\Validator;
 use BenSampo\Enum\Commands\MakeEnumCommand;
+use BenSampo\Enum\Commands\EnumAnnotateCommand;
 
 class EnumServiceProvider extends ServiceProvider
 {
@@ -18,7 +19,6 @@ class EnumServiceProvider extends ServiceProvider
     public function boot()
     {
         $this->bootCommands();
-
         $this->bootValidators();
     }
 
@@ -31,6 +31,7 @@ class EnumServiceProvider extends ServiceProvider
     {
         if ($this->app->runningInConsole()) {
             $this->commands([
+                EnumAnnotateCommand::class,
                 MakeEnumCommand::class,
             ]);
         }

--- a/tests/ApplicationTestCase.php
+++ b/tests/ApplicationTestCase.php
@@ -2,9 +2,10 @@
 
 namespace BenSampo\Enum\Tests;
 
+use Orchestra\Testbench\TestCase;
 use BenSampo\Enum\EnumServiceProvider;
 
-class ApplicationTestCase extends \Orchestra\Testbench\TestCase
+class ApplicationTestCase extends TestCase
 {
     protected function getPackageProviders($app)
     {


### PR DESCRIPTION
If you want your IDE to autocomplete the static instantiation helpers, you can
generate PHPDoc annotations through an artisan command.

     php artisan enum:annotate "App\Enums\UserType"

Example output from my project:

```php
<?php

declare(strict_types=1);

namespace App\Models\Patient;

use BenSampo\Enum\Enum;

/**
 * @method static static DR
 * @method static static DR_MED
 * @method static static PROF
 * @method static static PROF_DR
 * @method static static PROF_DR_MED
 */
final class PatientTitle extends Enum
{
    const DR = 'Dr.';
    const DR_MED = 'Dr. med.';
    const PROF = 'Prof.';
    const PROF_DR = 'Prof. Dr.';
    const PROF_DR_MED = 'Prof. Dr. med.';
}
```

PHPStorm understands the magic instantiation methods now:

![image](https://user-images.githubusercontent.com/12158000/57452025-0ef86780-7263-11e9-8e35-a939fbb40ead.png)
