### PR TITLE
Add getInstances method

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,53 @@ Returns an instance of the called enum. Read more about [enum instantiation](#in
 UserType::getInstance(UserType::Administrator);
 ```
 
+### getInstances(): array
+
+Returns an array of all possible instances of the called enum, keyed by the constant names.
+
+```php
+var_dump(UserType::getInstances());
+
+array(4) {
+  'Administrator' =>
+  class BenSampo\Enum\Tests\Enums\UserType#415 (3) {
+    public $key =>
+    string(13) "Administrator"
+    public $value =>
+    int(0)
+    public $description =>
+    string(13) "Administrator"
+  }
+  'Moderator' =>
+  class BenSampo\Enum\Tests\Enums\UserType#396 (3) {
+    public $key =>
+    string(9) "Moderator"
+    public $value =>
+    int(1)
+    public $description =>
+    string(9) "Moderator"
+  }
+  'Subscriber' =>
+  class BenSampo\Enum\Tests\Enums\UserType#393 (3) {
+    public $key =>
+    string(10) "Subscriber"
+    public $value =>
+    int(2)
+    public $description =>
+    string(10) "Subscriber"
+  }
+  'SuperAdministrator' =>
+  class BenSampo\Enum\Tests\Enums\UserType#102 (3) {
+    public $key =>
+    string(18) "SuperAdministrator"
+    public $value =>
+    int(3)
+    public $description =>
+    string(19) "Super administrator"
+  }
+}
+```
+
 ## Instantiation
 It can be useful to instantiate enums in order to pass them between functions with the benefit of type hinting. Additionally, it's impossible to instantiate an enum with an invalid value, therefore you can be certain that the passed value is always valid.
 

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -112,6 +112,21 @@ abstract class Enum implements EnumContract
     }
 
     /**
+     * Return instances of all the contained values.
+     *
+     * @return static[]
+     */
+    public static function getInstances(): array
+    {
+        return array_map(
+            function($constantValue) {
+                return new static($constantValue);
+            },
+            static::getConstants()
+        );
+    }
+
+    /**
      * Get all of the constants defined on the class.
      *
      * @return array

--- a/tests/EnumTest.php
+++ b/tests/EnumTest.php
@@ -119,4 +119,24 @@ class EnumTest extends TestCase
         $this->assertTrue(UserType::hasMacro('toFlippedArray'));
         $this->assertEquals(UserType::toFlippedArray(), array_flip(UserType::toArray()));
     }
+
+    public function test_enum_get_instances()
+    {
+        /** @var StringValues $administrator */
+        /** @var StringValues $moderator */
+        [
+            'Administrator' => $administrator,
+            'Moderator' => $moderator
+        ] = StringValues::getInstances();
+
+        $this->assertTrue(
+            $administrator->is(StringValues::Administrator)
+        );
+
+        $this->assertTrue(
+            $moderator->is(StringValues::Moderator)
+        );
+
+        var_dump(UserType::getInstances());
+    }
 }

--- a/tests/EnumTest.php
+++ b/tests/EnumTest.php
@@ -136,7 +136,5 @@ class EnumTest extends TestCase
         $this->assertTrue(
             $moderator->is(StringValues::Moderator)
         );
-
-        var_dump(UserType::getInstances());
     }
 }


### PR DESCRIPTION
### getInstances(): array

Returns an array of all possible instances of the called enum, keyed by the constant names.

```php
var_dump(UserType::getInstances());

array(4) {
  'Administrator' =>
  class BenSampo\Enum\Tests\Enums\UserType#415 (3) {
    public $key =>
    string(13) "Administrator"
    public $value =>
    int(0)
    public $description =>
    string(13) "Administrator"
  }
  'Moderator' =>
  class BenSampo\Enum\Tests\Enums\UserType#396 (3) {
    public $key =>
    string(9) "Moderator"
    public $value =>
    int(1)
    public $description =>
    string(9) "Moderator"
  }
  'Subscriber' =>
  class BenSampo\Enum\Tests\Enums\UserType#393 (3) {
    public $key =>
    string(10) "Subscriber"
    public $value =>
    int(2)
    public $description =>
    string(10) "Subscriber"
  }
  'SuperAdministrator' =>
  class BenSampo\Enum\Tests\Enums\UserType#102 (3) {
    public $key =>
    string(18) "SuperAdministrator"
    public $value =>
    int(3)
    public $description =>
    string(19) "Super administrator"
  }
}
```
