### PR TITLE
Cast the value before getInstance is called in setAttribute method

### DIFF
--- a/src/Traits/CastsEnums.php
+++ b/src/Traits/CastsEnums.php
@@ -35,6 +35,8 @@ trait CastsEnums
      */
     public function setAttribute($key, $value)
     {
+        $value = parent::getAttributeValue($key);
+
         if ($value !== null && $this->hasEnumCast($key)) {
             $enum = $this->enumCasts[$key];
 

--- a/src/Traits/CastsEnums.php
+++ b/src/Traits/CastsEnums.php
@@ -35,9 +35,12 @@ trait CastsEnums
      */
     public function setAttribute($key, $value)
     {
-        $value = parent::getAttributeValue($key);
-
         if ($value !== null && $this->hasEnumCast($key)) {
+
+            if ($this->hasCast($key)) {
+                $value = $this->castAttribute($key, $value);
+            }
+
             $enum = $this->enumCasts[$key];
 
             if ($value instanceOf $enum) {


### PR DESCRIPTION
When data is sent via. a form request, the value comes through as a string, and throws [`InvalidEnumMemberException`](https://github.com/BenSampo/laravel-enum/blob/master/src/Enum.php#L56).

>Value 0 doesn't exist in [0, 1]

You can set the property in the `$casts` array on the model, but this isn't called in the `setAttribute` method at present.

The PR adds in the standard Laravel casts modification on the value.