### PR TITLE
feat: allow enums to be cast to string

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,17 @@ $userType->description; // Super Administrator
 
 This is particularly useful if you're passing an enum instance to a blade view.
 
+### Instance Casting
+
+Enum instances can be cast to strings as they implement the `__toString()` magic method.  
+This also means they can be echo'd, for example in blade views.
+
+```php
+$userType = UserType::getInstance(UserType::SuperAdministrator);
+
+(string) $userType // '0'
+```
+
 ### Instance Equality
 
 You can check the equality of an instance against a valid enum value by passing it to the `is` method.

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -86,6 +86,14 @@ abstract class Enum implements EnumContract
     }
 
     /**
+     * @return string
+     */
+    public function __toString(): string
+    {
+        return (string) $this->value;
+    }
+
+    /**
      * Checks the equality of the value against the enum instance.
      *
      * @param  mixed  $enumValue

--- a/tests/EnumCastTest.php
+++ b/tests/EnumCastTest.php
@@ -56,4 +56,12 @@ class EnumCastTest extends TestCase
 
         $this->assertNull($model->user_type);
     }
+
+    public function test_that_model_with_enum_can_be_cast_to_array()
+    {
+        $model = app(Example::class);
+        $model->user_type = UserType::Moderator();
+
+        $this->assertSame(['user_type' => 1], $model->toArray());
+    }
 }

--- a/tests/EnumTest.php
+++ b/tests/EnumTest.php
@@ -137,4 +137,19 @@ class EnumTest extends TestCase
             $moderator->is(StringValues::Moderator)
         );
     }
+
+    public function test_enum_can_be_cast_to_string()
+    {
+        $enumWithZeroIntegerValue = new UserType(UserType::Administrator);
+        $enumWithPositiveIntegerValue = new UserType(UserType::SuperAdministrator);
+        $enumWithStringValue = new StringValues(StringValues::Moderator);
+
+        // Numbers should be cast to strings
+        $this->assertSame('0', (string) $enumWithZeroIntegerValue);
+        $this->assertSame('3', (string) $enumWithPositiveIntegerValue);
+
+        // Strings should just be returned
+        $this->assertSame(StringValues::Moderator, (string) $enumWithStringValue);
+
+    }
 }


### PR DESCRIPTION
- Implement the `__toString()` magic method on Enum Class
- Update tests & documentation

Closes #65 