### PR TITLE
fix: fix double annotations on enums

### DIFF
--- a/src/Commands/EnumAnnotateCommand.php
+++ b/src/Commands/EnumAnnotateCommand.php
@@ -55,7 +55,7 @@ class EnumAnnotateCommand extends AbstractAnnotationCommand
         $constants = $reflectionClass->getConstants();
 
         $existingTags = array_filter($originalTags, function (TagInterface $tag) use ($constants) {
-            return !$tag instanceof MethodTag || !in_array($tag->getMethodName(), $constants, true);
+            return !$tag instanceof MethodTag || !in_array($tag->getMethodName(), array_keys($constants), true);
         });
 
         return collect($constants)

--- a/tests/ArtisanCommandsTest.php
+++ b/tests/ArtisanCommandsTest.php
@@ -3,6 +3,7 @@
 namespace BenSampo\Enum\Tests;
 
 use BenSampo\Enum\Tests\Enums\Annotate\AnnotateTestOneEnum;
+use BenSampo\Enum\Tests\Enums\MixedKeyFormatsAnnotated;
 use BenSampo\Enum\Tests\Models\AnnotatedExample;
 use Illuminate\Contracts\Console\Kernel;
 use Illuminate\Filesystem\Filesystem;
@@ -85,6 +86,19 @@ class ArtisanCommandsTest extends ApplicationTestCase
         $this->artisan('enum:annotate-model', ['class' => AnnotatedExample::class])->assertExitCode(0);
 
         $newClass = $fileSystem->get(__DIR__ . '/Models/AnnotatedExample.php');
+        $this->assertSame($original, $newClass);
+    }
+
+    public function test_annotate_enum_with_existing_docblock_is_not_changed()
+    {
+        /** @var Filesystem $fileSystem */
+        $fileSystem = $this->app[Filesystem::class];
+
+        $original = $fileSystem->get(__DIR__ . '/Enums/MixedKeyFormatsAnnotated.php');
+
+        $this->artisan('enum:annotate', ['class' => MixedKeyFormatsAnnotated::class])->assertExitCode(0);
+
+        $newClass = $fileSystem->get(__DIR__ . '/Enums/MixedKeyFormatsAnnotated.php');
         $this->assertSame($original, $newClass);
     }
 }

--- a/tests/Enums/MixedKeyFormatsAnnotated.php
+++ b/tests/Enums/MixedKeyFormatsAnnotated.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace BenSampo\Enum\Tests\Enums;
+
+use BenSampo\Enum\Enum;
+
+/**
+ * @method static static Normal()
+ * @method static static MultiWordKeyName()
+ * @method static static UPPERCASE()
+ * @method static static UPPERCASE_SNAKE_CASE()
+ * @method static static lowercase_snake_case()
+ */
+final class MixedKeyFormatsAnnotated extends Enum
+{
+    const Normal = 1;
+    const MultiWordKeyName = 2;
+    const UPPERCASE = 3;
+    const UPPERCASE_SNAKE_CASE = 4;
+    const lowercase_snake_case = 5;
+}


### PR DESCRIPTION
It seems I missed an `array_keys`, and didn't have a test for it (only for models).
I've added the test + fixed the bug, sorry 😞 
