### PR TITLE
Laravel 5.9 to remove helper string functions

### DIFF
--- a/src/Enum.php
+++ b/src/Enum.php
@@ -3,6 +3,7 @@
 namespace BenSampo\Enum;
 
 use ReflectionClass;
+use Illuminate\Support\Str;
 use Illuminate\Support\Facades\Lang;
 use Illuminate\Support\Traits\Macroable;
 use BenSampo\Enum\Contracts\EnumContract;
@@ -326,7 +327,7 @@ abstract class Enum implements EnumContract
             $key = strtolower($key);
         }
 
-        return ucfirst(str_replace('_', ' ', snake_case($key)));
+        return ucfirst(str_replace('_', ' ', Str::snake($key)));
     }
 
     /**


### PR DESCRIPTION
In the next version of Laravel helper functions like `snake_case` do not work. If I recall there's an article someone on Laravel News talking about this change. I've been using the in a project that's using Laravel 5.9 and just ran into this today so I figured I'd send a PR.