### PR TITLE
feat: add `in` method on enum

### DIFF
--- a/src/Enum.php
+++ b/src/Enum.php
@@ -2,13 +2,13 @@
 
 namespace BenSampo\Enum;
 
-use ReflectionClass;
-use Illuminate\Support\Str;
-use Illuminate\Support\Facades\Lang;
-use Illuminate\Support\Traits\Macroable;
 use BenSampo\Enum\Contracts\EnumContract;
 use BenSampo\Enum\Contracts\LocalizedEnum;
 use BenSampo\Enum\Exceptions\InvalidEnumMemberException;
+use Illuminate\Support\Facades\Lang;
+use Illuminate\Support\Str;
+use Illuminate\Support\Traits\Macroable;
+use ReflectionClass;
 
 abstract class Enum implements EnumContract
 {
@@ -56,7 +56,7 @@ abstract class Enum implements EnumContract
         if (!static::hasValue($enumValue)) {
             throw new InvalidEnumMemberException($enumValue, $this);
         }
-        
+
         $this->value = $enumValue;
         $this->key = static::getKey($enumValue);
         $this->description = static::getDescription($enumValue);
@@ -107,6 +107,19 @@ abstract class Enum implements EnumContract
         }
 
         return $this->value === $enumValue;
+    }
+
+    /**
+     * Checks if the enum instance's value exists is one of the passed array
+     *
+     * @param array $values
+     * @param bool  $strict
+     *
+     * @return bool
+     */
+    public function in(array $values, bool $strict = true): bool
+    {
+        return in_array($this->value, $values, $strict);
     }
 
     /**

--- a/tests/EnumTest.php
+++ b/tests/EnumTest.php
@@ -48,7 +48,7 @@ class EnumTest extends TestCase
         $this->assertEquals(1, UserType::getValue('Moderator'));
         $this->assertEquals(3, UserType::getValue('SuperAdministrator'));
     }
-    
+
     public function test_enum_get_value_using_string_key()
     {
         $this->assertEquals('administrator', StringValues::getValue('Administrator'));
@@ -136,6 +136,20 @@ class EnumTest extends TestCase
         $this->assertTrue(
             $moderator->is(StringValues::Moderator)
         );
+    }
+
+    public function test_enum_instance_in_array()
+    {
+        $administrator = new StringValues(StringValues::Administrator);
+
+        $this->assertTrue($administrator->in([StringValues::Moderator, StringValues::Administrator]));
+        $this->assertTrue($administrator->in([StringValues::Administrator]));
+        $this->assertFalse($administrator->in([StringValues::Moderator]));
+
+        $mixed = new MixedKeyFormats(MixedKeyFormats::UPPERCASE_SNAKE_CASE);
+
+        $this->assertTrue($mixed->in([true], false)); // Strict checking turned off
+        $this->assertFalse($mixed->in([true], true)); // Strict checking turned on
     }
 
     public function test_enum_can_be_cast_to_string()


### PR DESCRIPTION
This adds an `in` method to enum instances, which can be used like so:
```php
$booking->status->in([Status::DRAFT, Status::PENDING, Status::REVIEW])
```

It also supports turning off strict mode by passing `false` as the second parameter. 

Closes #79 