### PR TITLE
Make equality checks work with both enum instances and arbitrary values

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,20 +166,18 @@ $userType = UserType::getInstance(UserType::SuperAdministrator);
 
 ### Instance Equality
 
-You can check the equality of an instance against a valid enum value by passing it to the `is` method.
+You can check the equality of an instance against any value by passing it to the `is` method.
 
 ``` php
 $admin = UserType::getInstance(UserType::Administrator);
 
 $admin->is(UserType::Administrator);   // true
 $admin->is($admin);                    // true
-$admin->is(UserType::Administrator()); // true
+$admin->is(new UserType(UserType::Administrator)); // true
 
 $admin->is(UserType::Moderator);       // false
 $admin->is(UserType::Moderator());     // false
-
-$admin->is('random-value');            // Throws InvalidEnumMemberException exception
-$admin->is('random-value');            // Throws InvalidEnumMemberException exception
+$admin->is('random-value');            // false
 ```
 
 You can also check to see if the instance's value matches against an array of possible values using the `in` method.
@@ -187,12 +185,11 @@ You can also check to see if the instance's value matches against an array of po
 ```php
 $admin = UserType::getInstance(UserType::Administrator);
 
-$admin->in([UserType::Moderator, UserType::Administrator]);     // Returns true
-$admin->in([UserType::Moderator(), UserType::Administrator()]); // Returns true
+$admin->in([UserType::Moderator, UserType::Administrator]);     // true
+$admin->in([UserType::Moderator(), UserType::Administrator()]); // true
 
-$admin->in([UserType::Moderator, UserType::Subscriber]);        // Returns false
-
-$admin->in(['random-value']);                                   // Throws InvalidEnumMemberException exception
+$admin->in([UserType::Moderator, UserType::Subscriber]);        // false
+$admin->in(['random-value']);                                   // false
 ```
 
 ### Type Hinting

--- a/README.md
+++ b/README.md
@@ -169,11 +169,17 @@ $userType = UserType::getInstance(UserType::SuperAdministrator);
 You can check the equality of an instance against a valid enum value by passing it to the `is` method.
 
 ``` php
-$userType = UserType::getInstance(UserType::SuperAdministrator);
+$admin = UserType::getInstance(UserType::Administrator);
 
-$userType->is(UserType::SuperAdministrator); // Returns true
-$userType->is(UserType::Moderator); // Returns false
-$userType->is(UserType::InvalidKey); // Throws InvalidEnumMemberException exception
+$admin->is(UserType::Administrator);   // true
+$admin->is($admin);                    // true
+$admin->is(UserType::Administrator()); // true
+
+$admin->is(UserType::Moderator);       // false
+$admin->is(UserType::Moderator());     // false
+
+$admin->is('random-value');            // Throws InvalidEnumMemberException exception
+$admin->is('random-value');            // Throws InvalidEnumMemberException exception
 ```
 
 You can also check to see if the instance's value matches against an array of possible values using the `in` method.

--- a/README.md
+++ b/README.md
@@ -185,10 +185,14 @@ $admin->is('random-value');            // Throws InvalidEnumMemberException exce
 You can also check to see if the instance's value matches against an array of possible values using the `in` method.
 
 ```php
-$userType = UserType::getInstance(UserType::SuperAdministrator);
+$admin = UserType::getInstance(UserType::Administrator);
 
-$userType->in([UserType::Moderator, UserType::SuperAdministrator]); // Returns true
-$userType->in([UserType::Moderator, UserType::Subscriber]); // Returns false
+$admin->in([UserType::Moderator, UserType::Administrator]);     // Returns true
+$admin->in([UserType::Moderator(), UserType::Administrator()]); // Returns true
+
+$admin->in([UserType::Moderator, UserType::Subscriber]);        // Returns false
+
+$admin->in(['random-value']);                                   // Throws InvalidEnumMemberException exception
 ```
 
 ### Type Hinting

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ $admin = UserType::getInstance(UserType::Administrator);
 
 $admin->is(UserType::Administrator);   // true
 $admin->is($admin);                    // true
-$admin->is(new UserType(UserType::Administrator)); // true
+$admin->is(UserType::Administrator()); // true
 
 $admin->is(UserType::Moderator);       // false
 $admin->is(UserType::Moderator());     // false

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -95,9 +95,9 @@ abstract class Enum implements EnumContract
     }
 
     /**
-     * Checks the equality of the value against the enum instance.
+     * Checks if this instance is equal to the given enum instance or value.
      *
-     * @param  mixed  $enumValue
+     * @param  static|mixed  $enumValue
      * @return bool
      */
     public function is($enumValue): bool
@@ -114,16 +114,20 @@ abstract class Enum implements EnumContract
     }
 
     /**
-     * Checks if the enum instance's value exists is one of the passed array
+     * Checks if a matching enum instance or value is in the given array.
      *
-     * @param array $values
-     * @param bool  $strict
-     *
+     * @param  (mixed|static)[]  $values
      * @return bool
      */
-    public function in(array $values, bool $strict = true): bool
+    public function in(array $values): bool
     {
-        return in_array($this->value, $values, $strict);
+        foreach ($values as $value) {
+            if ($this->is($value)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -106,10 +106,6 @@ abstract class Enum implements EnumContract
             return $this->value === $enumValue->value;
         }
 
-        if (!static::hasValue($enumValue)) {
-            throw new InvalidEnumMemberException($enumValue, $this);
-        }
-
         return $this->value === $enumValue;
     }
 

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -103,7 +103,7 @@ abstract class Enum implements EnumContract
     public function is($enumValue): bool
     {
         if ($enumValue instanceof static) {
-           return $this->value === $enumValue->value;
+            return $this->value === $enumValue->value;
         }
 
         if (!static::hasValue($enumValue)) {

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -102,6 +102,10 @@ abstract class Enum implements EnumContract
      */
     public function is($enumValue): bool
     {
+        if ($enumValue instanceof static) {
+           return $this->value === $enumValue->value;
+        }
+
         if (!static::hasValue($enumValue)) {
             throw new InvalidEnumMemberException($enumValue, $this);
         }

--- a/tests/EnumComparisonTest.php
+++ b/tests/EnumComparisonTest.php
@@ -51,4 +51,20 @@ class EnumComparisonTest extends TestCase
 
         StringValues::getInstance(UserType::Subscriber)->is('InvalidValue');
     }
+
+    public function test_enum_instance_in_array()
+    {
+        $administrator = new StringValues(StringValues::Administrator);
+
+        $this->assertTrue($administrator->in([
+            StringValues::Moderator,
+            StringValues::Administrator
+        ]));
+        $this->assertTrue($administrator->in([
+            new StringValues(StringValues::Moderator),
+            new StringValues(StringValues::Administrator)
+        ]));
+        $this->assertTrue($administrator->in([StringValues::Administrator]));
+        $this->assertFalse($administrator->in([StringValues::Moderator]));
+    }
 }

--- a/tests/EnumComparisonTest.php
+++ b/tests/EnumComparisonTest.php
@@ -2,7 +2,6 @@
 
 namespace BenSampo\Enum\Tests;
 
-use BenSampo\Enum\Exceptions\InvalidEnumMemberException;
 use BenSampo\Enum\Tests\Enums\StringValues;
 use BenSampo\Enum\Tests\Enums\UserType;
 use PHPUnit\Framework\TestCase;

--- a/tests/EnumComparisonTest.php
+++ b/tests/EnumComparisonTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace BenSampo\Enum\Tests;
+
+use BenSampo\Enum\Exceptions\InvalidEnumMemberException;
+use BenSampo\Enum\Tests\Enums\StringValues;
+use BenSampo\Enum\Tests\Enums\UserType;
+use PHPUnit\Framework\TestCase;
+
+class EnumComparisonTest extends TestCase
+{
+    public function test_comparison_against_constant_matching()
+    {
+        $admin = UserType::getInstance(UserType::Administrator);
+
+        $this->assertTrue($admin->is(UserType::Administrator));
+    }
+
+    public function test_comparison_against_constant_not_matching()
+    {
+        $admin = UserType::getInstance(UserType::Administrator);
+
+        $this->assertFalse($admin->is(UserType::SuperAdministrator));
+    }
+
+    public function test_comparison_against_itself_matches()
+    {
+        $admin = UserType::getInstance(UserType::Administrator);
+
+        $this->assertTrue($admin->is($admin));
+    }
+
+    public function test_comparison_against_other_instances_matches()
+    {
+        $admin = UserType::getInstance(UserType::Administrator);
+
+        $this->assertTrue($admin->is($admin));
+    }
+
+    public function test_comparison_against_other_instances_not_matching()
+    {
+        $admin = UserType::getInstance(UserType::Administrator);
+        $superAdmin = UserType::getInstance(UserType::SuperAdministrator);
+
+        $this->assertFalse($admin->is($superAdmin));
+    }
+
+    public function test_an_exception_is_thrown_when_trying_to_check_an_enum_instance_value_with_an_invalid_value()
+    {
+        $this->expectException(InvalidEnumMemberException::class);
+
+        StringValues::getInstance(UserType::Subscriber)->is('InvalidValue');
+    }
+}

--- a/tests/EnumComparisonTest.php
+++ b/tests/EnumComparisonTest.php
@@ -9,18 +9,19 @@ use PHPUnit\Framework\TestCase;
 
 class EnumComparisonTest extends TestCase
 {
-    public function test_comparison_against_constant_matching()
+    public function test_comparison_against_plain_value_matching()
     {
         $admin = UserType::getInstance(UserType::Administrator);
 
         $this->assertTrue($admin->is(UserType::Administrator));
     }
 
-    public function test_comparison_against_constant_not_matching()
+    public function test_comparison_against_plain_value_not_matching()
     {
         $admin = UserType::getInstance(UserType::Administrator);
 
         $this->assertFalse($admin->is(UserType::SuperAdministrator));
+        $this->assertFalse($admin->is('some-random-value'));
     }
 
     public function test_comparison_against_itself_matches()
@@ -33,8 +34,9 @@ class EnumComparisonTest extends TestCase
     public function test_comparison_against_other_instances_matches()
     {
         $admin = UserType::getInstance(UserType::Administrator);
+        $anotherAdmin = UserType::getInstance(UserType::Administrator);
 
-        $this->assertTrue($admin->is($admin));
+        $this->assertTrue($admin->is($anotherAdmin));
     }
 
     public function test_comparison_against_other_instances_not_matching()
@@ -43,13 +45,6 @@ class EnumComparisonTest extends TestCase
         $superAdmin = UserType::getInstance(UserType::SuperAdministrator);
 
         $this->assertFalse($admin->is($superAdmin));
-    }
-
-    public function test_an_exception_is_thrown_when_trying_to_check_an_enum_instance_value_with_an_invalid_value()
-    {
-        $this->expectException(InvalidEnumMemberException::class);
-
-        StringValues::getInstance(UserType::Subscriber)->is('InvalidValue');
     }
 
     public function test_enum_instance_in_array()

--- a/tests/EnumInstanceTest.php
+++ b/tests/EnumInstanceTest.php
@@ -25,21 +25,6 @@ class EnumInstanceTest extends TestCase
         UserType::getInstance('InvalidValue');
     }
 
-    public function test_instance_can_check_it_is_set_to_an_enum_value()
-    {
-        $userType = UserType::getInstance(UserType::Administrator);
-
-        $this->assertTrue($userType->is(UserType::Administrator));
-        $this->assertFalse($userType->is(UserType::SuperAdministrator));
-    }
-
-    public function test_an_exception_is_thrown_when_trying_to_check_an_enum_instance_value_with_an_invalid_value()
-    {
-        $this->expectException(InvalidEnumMemberException::class);
-
-        StringValues::getInstance(UserType::Subscriber)->is('InvalidValue');
-    }
-
     public function test_can_get_the_value_for_an_enum_instance()
     {
         $userType = UserType::getInstance(UserType::Administrator);
@@ -69,7 +54,7 @@ class EnumInstanceTest extends TestCase
     public function test_an_exception_is_thrown_when_trying_to_get_enum_instance_by_calling_an_enum_key_as_a_static_method_which_does_not_exist()
     {
         $this->expectException(\BadMethodCallException::class);
-        
+
         UserType::KeyWhichDoesNotExist();
     }
 }

--- a/tests/EnumTest.php
+++ b/tests/EnumTest.php
@@ -138,20 +138,6 @@ class EnumTest extends TestCase
         );
     }
 
-    public function test_enum_instance_in_array()
-    {
-        $administrator = new StringValues(StringValues::Administrator);
-
-        $this->assertTrue($administrator->in([StringValues::Moderator, StringValues::Administrator]));
-        $this->assertTrue($administrator->in([StringValues::Administrator]));
-        $this->assertFalse($administrator->in([StringValues::Moderator]));
-
-        $mixed = new MixedKeyFormats(MixedKeyFormats::UPPERCASE_SNAKE_CASE);
-
-        $this->assertTrue($mixed->in([true], false)); // Strict checking turned off
-        $this->assertFalse($mixed->in([true], true)); // Strict checking turned on
-    }
-
     public function test_enum_can_be_cast_to_string()
     {
         $enumWithZeroIntegerValue = new UserType(UserType::Administrator);


### PR DESCRIPTION
This PR adds the capability to directly compare Enum instances with each other and with arbitrary values.

Comparing against values that are not valid allowed values of the Enum now simply returns `false` instead of throwing.

You can check the equality of an instance against any value by passing it to the `is` method.

``` php
$admin = UserType::getInstance(UserType::Administrator);

$admin->is(UserType::Administrator);   // true
$admin->is($admin);                    // true
$admin->is(UserType::Administrator()); // true

$admin->is(UserType::Moderator);       // false
$admin->is(UserType::Moderator());     // false
$admin->is('random-value');            // false
```

You can also check to see if the instance's value matches against an array of possible values using the `in` method.

```php
$admin = UserType::getInstance(UserType::Administrator);

$admin->in([UserType::Moderator, UserType::Administrator]);     // true
$admin->in([UserType::Moderator(), UserType::Administrator()]); // true

$admin->in([UserType::Moderator, UserType::Subscriber]);        // false
$admin->in(['random-value']);                                   // false
```
