### PR TITLE
Feature: Array of Enums

### DIFF
--- a/src/Traits/CastsEnums.php
+++ b/src/Traits/CastsEnums.php
@@ -42,8 +42,12 @@ trait CastsEnums
             if ($value instanceOf $enum) {
                 $this->attributes[$key] = $value->value;
             } elseif ($this->hasCast($key) && $this->getCasts()[$key] === 'array') {
-                parent::setAttribute($key, collect($value)->map(function ($value) {
-                    return $value->value;
+                parent::setAttribute($key, collect($value)->map(function ($value) use ($enum) {
+                    if ($value instanceOf $enum) {
+                        return $value->value;
+                    }
+
+                    return $enum::getInstance($value)->value;
                 }));
             } else {
                 if ($this->hasCast($key)) {

--- a/src/Traits/CastsEnums.php
+++ b/src/Traits/CastsEnums.php
@@ -41,6 +41,10 @@ trait CastsEnums
 
             if ($value instanceOf $enum) {
                 $this->attributes[$key] = $value->value;
+            } elseif ($this->hasCast($key) && $this->getCasts()[$key] === 'array') {
+                parent::setAttribute($key, collect($value)->map(function ($value) {
+                    return $value->value;
+                }));
             } else {
                 if ($this->hasCast($key)) {
                     $value = $this->castAttribute($key, $value);
@@ -71,15 +75,19 @@ trait CastsEnums
      *
      * @param  string  $key
      * @param  mixed  $value
-     * @return \BenSampo\Enum\Enum|null
+     * @return \BenSampo\Enum\Enum|array|null
      */
-    protected function castToEnum($key, $value): ?Enum
+    protected function castToEnum($key, $value)
     {
         /** @var \BenSampo\Enum\Enum $enum */
         $enum = $this->enumCasts[$key];
 
         if ($value === null || $value instanceOf Enum) {
             return $value;
+        } elseif ($this->hasCast($key) && $this->getCasts()[$key] === 'array') {
+            return collect($value)->map(function ($value) use ($enum) {
+                return $enum::getInstance($value);
+            })->toArray();
         } else {
             return $enum::getInstance($value);
         }

--- a/tests/EnumCastTest.php
+++ b/tests/EnumCastTest.php
@@ -5,6 +5,7 @@ namespace BenSampo\Enum\Tests;
 use PHPUnit\Framework\TestCase;
 use BenSampo\Enum\Tests\Enums\UserType;
 use BenSampo\Enum\Tests\Models\Example;
+use BenSampo\Enum\Tests\Models\ExampleArrayable;
 use BenSampo\Enum\Exceptions\InvalidEnumMemberException;
 
 class EnumCastTest extends TestCase
@@ -25,12 +26,28 @@ class EnumCastTest extends TestCase
         $this->assertEquals(UserType::Moderator(), $model->user_type);
     }
 
+    public function test_can_set_model_value_using_enum_instance_array()
+    {
+        $model = app(ExampleArrayable::class);
+        $model->user_types = [UserType::Moderator(), UserType::Administrator()];
+
+        $this->assertEquals([UserType::Moderator(), UserType::Administrator()], $model->user_types);
+    }
+
     public function test_can_set_model_value_using_enum_value()
     {
         $model = app(Example::class);
         $model->user_type = UserType::Moderator;
 
         $this->assertEquals(UserType::Moderator(), $model->user_type);
+    }
+
+    public function test_can_set_model_value_using_enum_value_array()
+    {
+        $model = app(ExampleArrayable::class);
+        $model->user_types = [UserType::Moderator, UserType::Administrator];
+
+        $this->assertEquals([UserType::Moderator(), UserType::Administrator()], $model->user_types);
     }
 
     public function test_cannot_set_model_value_using_invalid_enum_value()
@@ -42,12 +59,28 @@ class EnumCastTest extends TestCase
 
     }
 
+    public function test_cannot_set_model_value_using_invalid_enum_value_array()
+    {
+        $this->expectException(InvalidEnumMemberException::class);
+
+        $model = app(ExampleArrayable::class);
+        $model->user_types = [1, 5];
+    }
+
     public function test_getting_model_value_returns_enum_instance()
     {
         $model = app(Example::class);
         $model->user_type = UserType::Moderator;
 
         $this->assertInstanceOf(UserType::class, $model->user_type);
+    }
+
+    public function test_getting_model_value_returns_enum_instance_array()
+    {
+        $model = app(ExampleArrayable::class);
+        $model->user_types = [UserType::Moderator, UserType::Administrator];
+
+        $this->assertContainsOnlyInstancesOf(UserType::class, $model->user_types);
     }
 
     public function test_can_get_and_set_null_on_enum_castable()
@@ -58,11 +91,27 @@ class EnumCastTest extends TestCase
         $this->assertNull($model->user_type);
     }
 
+    public function test_can_get_and_set_null_on_enum_castable_array()
+    {
+        $model = app(ExampleArrayable::class);
+        $model->user_types = null;
+
+        $this->assertNull($model->user_types);
+    }
+
     public function test_that_model_with_enum_can_be_cast_to_array()
     {
         $model = app(Example::class);
         $model->user_type = UserType::Moderator();
 
         $this->assertSame(['user_type' => 1], $model->toArray());
+    }
+
+    public function test_that_model_with_enum_array_can_be_cast_to_array()
+    {
+        $model = app(ExampleArrayable::class);
+        $model->user_types = [UserType::Moderator(), UserType::Administrator()];
+
+        $this->assertSame(['user_types' => [1, 0]], $model->toArray());
     }
 }

--- a/tests/Models/ExampleArrayable.php
+++ b/tests/Models/ExampleArrayable.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace BenSampo\Enum\Tests\Models;
+
+use BenSampo\Enum\Traits\CastsEnums;
+use BenSampo\Enum\Tests\Enums\UserType;
+use Illuminate\Database\Eloquent\Model;
+
+class ExampleArrayable extends Model
+{
+    use CastsEnums;
+
+    protected $casts = [
+        'user_types' => 'array',
+    ];
+
+    protected $enumCasts = [
+        'user_types' => UserType::class,
+    ];
+
+    protected $fillable = [
+        'user_types',
+    ];
+}


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Added or updated the [README.md](../README.md)

**Related Issue/Intent**

An interesting feature I needed recently was to allow for an array of Enums to be stored in a single attribute. I created my own trait to do this at the time, but I then thought I'd convert this into a feature PR in case you're interested in it. This might not be the right approach, so feel free to use it or not.

***Example***

Given a class such as this:

```php
class ExampleArrayable extends Model
{
    use CastsEnums;

    protected $casts = [
        'user_types' => 'array',
    ];

    protected $enumCasts = [
        'user_types' => UserType::class,
    ];
}
```

You are able to do the following:

```php
$model = app(ExampleArrayable::class);
$model->user_types = [UserType::Moderator, UserType::Administrator];
```

And you can go further and do things like this:

```php
UserType::Administrator()->in($model->user_types);
```

**Changes**

- Allow for the `array` type to be used in the model's `$casts` attribute.
- Modify trait to correctly cast each value to its appropriate Enum instance.
- Add the relevant tests for this in `EnumCastTest`.

**Breaking changes**

None.