### PR TITLE
Added an 'isNot()' method, purely for convenience.

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,20 @@ $admin->is(UserType::Moderator());     // false
 $admin->is('random-value');            // false
 ```
 
+For convenience, there is also an `isNot` method.
+
+``` php
+$admin = UserType::getInstance(UserType::Administrator);
+
+$admin->isNot(UserType::Administrator);   // false
+$admin->isNot($admin);                    // false
+$admin->isNot(UserType::Administrator()); // false
+
+$admin->isNot(UserType::Moderator);       // true
+$admin->isNot(UserType::Moderator());     // true
+$admin->isNot('random-value');            // true
+```
+
 You can also check to see if the instance's value matches against an array of possible values using the `in` method.
 
 ```php
@@ -227,7 +241,7 @@ use Illuminate\Database\Eloquent\Model;
 class Example extends Model
 {
     use CastsEnums;
-    
+
     protected $enumCasts = [
         // 'attribute_name' => Enum::class
         'user_type' => UserType::class,
@@ -236,7 +250,7 @@ class Example extends Model
 ```
 
 Now, when you access the `user_type` attribute of your `Example` model,
-the underlying value will be returned as a `UserType` enum. 
+the underlying value will be returned as a `UserType` enum.
 
 ```php
 $example = Example::first();
@@ -353,7 +367,7 @@ return [
 ```
 
 Now, you just need to make sure that your enum implements the `LocalizedEnum` interface as demonstrated below:
- 
+
 ```php
 use BenSampo\Enum\Enum;
 use BenSampo\Enum\Contracts\LocalizedEnum;

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ This is particularly useful if you're passing an enum instance to a blade view.
 ### Instance Casting
 
 Enum instances can be cast to strings as they implement the `__toString()` magic method.  
-This also means they can be echo'd, for example in blade views.
+This also means they can be echoed in blade views, for example.
 
 ```php
 $userType = UserType::getInstance(UserType::SuperAdministrator);
@@ -169,7 +169,7 @@ $userType = UserType::getInstance(UserType::SuperAdministrator);
 
 ### Instance Equality
 
-You can check the equality of an instance against any value by passing it to the `is` method.
+You can check the equality of an instance against any value by passing it to the `is` method. For convenience, there is also an `isNot` method which is the exact reverse of the `is` method.
 
 ``` php
 $admin = UserType::getInstance(UserType::Administrator);
@@ -181,20 +181,6 @@ $admin->is(UserType::Administrator()); // true
 $admin->is(UserType::Moderator);       // false
 $admin->is(UserType::Moderator());     // false
 $admin->is('random-value');            // false
-```
-
-For convenience, there is also an `isNot` method.
-
-``` php
-$admin = UserType::getInstance(UserType::Administrator);
-
-$admin->isNot(UserType::Administrator);   // false
-$admin->isNot($admin);                    // false
-$admin->isNot(UserType::Administrator()); // false
-
-$admin->isNot(UserType::Moderator);       // true
-$admin->isNot(UserType::Moderator());     // true
-$admin->isNot('random-value');            // true
 ```
 
 You can also check to see if the instance's value matches against an array of possible values using the `in` method.

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -110,6 +110,17 @@ abstract class Enum implements EnumContract
     }
 
     /**
+     * Checks if this instance is not equal to the given enum instance or value.
+     *
+     * @param  static|mixed  $enumValue
+     * @return bool
+     */
+    public function isNot($enumValue): bool
+    {
+        return ! $this->is($enumValue);
+    }
+
+    /**
      * Checks if a matching enum instance or value is in the given array.
      *
      * @param  (mixed|static)[]  $values

--- a/tests/EnumComparisonTest.php
+++ b/tests/EnumComparisonTest.php
@@ -21,6 +21,8 @@ class EnumComparisonTest extends TestCase
 
         $this->assertFalse($admin->is(UserType::SuperAdministrator));
         $this->assertFalse($admin->is('some-random-value'));
+        $this->assertTrue($admin->isNot(UserType::SuperAdministrator));
+        $this->assertTrue($admin->isNot('some-random-value'));
     }
 
     public function test_comparison_against_itself_matches()


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Added or updated the [README.md](../README.md)

**Related Issue/Intent**

A purely cosmetic change to the code that would be written by users of this package: perhaps a more 'Laravel' way of writing code. No related issue.

**Changes**

Instead of writing `! is()`, we can now write `isNot()`, (e.g.):

Previously: `return ! $user->role->is(UserRole::Admin);`
With this PR: `return $user->role->isNot(UserRole::Admin);`

I believe that `isNot()` is clearer than `! is()`. But this is purely subjective and I won't be at all offended if this PR is closed. :)

(Also there was some accidental minor cleanup of white space done by my editor.)

**Breaking changes**

None.