### PR TITLE
Add __toString to Enum rules

### DIFF
--- a/src/Rules/EnumKey.php
+++ b/src/Rules/EnumKey.php
@@ -7,6 +7,11 @@ use Illuminate\Contracts\Validation\Rule;
 class EnumKey implements Rule
 {
     /**
+     * The name of the rule.
+     */
+    protected $rule = 'enum_key';
+    
+    /**
      * @var string|\BenSampo\Enum\Enum
      */
     protected $enumClass;
@@ -46,5 +51,17 @@ class EnumKey implements Rule
     public function message()
     {
         return 'The key you have entered is invalid.';
+    }
+    
+    /**
+     * Convert the rule to a validation string.
+     *
+     * @return string
+     *
+     * @see \Illuminate\Validation\ValidationRuleParser::parseParameters
+     */
+    public function __toString()
+    {
+        return "{$this->rule}:{$this->enumClass}";
     }
 }

--- a/src/Rules/EnumValue.php
+++ b/src/Rules/EnumValue.php
@@ -7,6 +7,11 @@ use Illuminate\Contracts\Validation\Rule;
 class EnumValue implements Rule
 {
     /**
+     * The name of the rule.
+     */
+    protected $rule = 'enum_value';
+    
+    /**
      * @var string|\BenSampo\Enum\Enum
      */
     protected $enumClass;
@@ -53,5 +58,19 @@ class EnumValue implements Rule
     public function message()
     {
         return 'The value you have entered is invalid.';
+    }
+    
+    /**
+     * Convert the rule to a validation string.
+     *
+     * @return string
+     *
+     * @see \Illuminate\Validation\ValidationRuleParser::parseParameters
+     */
+    public function __toString()
+    {
+        $strict = $this->strict ? 'true' : 'false';
+        
+        return "{$this->rule}:{$this->enumClass},{$strict}";
     }
 }

--- a/tests/EnumKeyTest.php
+++ b/tests/EnumKeyTest.php
@@ -37,4 +37,11 @@ class EnumKeyTest extends TestCase
 
         (new EnumKey('PathToAClassThatDoesntExist'))->passes('', 'Test');
     }
+    
+    public function test_can_serialize_to_string()
+    {
+        $rule = new EnumKey(UserType::class);
+        
+        $this->assertEquals('enum_key:' . UserType::class, (string) $rule);
+    }
 }

--- a/tests/EnumValueTest.php
+++ b/tests/EnumValueTest.php
@@ -48,4 +48,18 @@ class EnumValueTest extends TestCase
 
         (new EnumValue('PathToAClassThatDoesntExist'))->passes('', 'Test');
     }
+    
+    public function test_can_serialize_to_string_without_strict_type_checking()
+    {
+        $rule = new EnumValue(UserType::class, false);
+    
+        $this->assertEquals('enum_value:' . UserType::class . ',false', (string) $rule);
+    }
+    
+    public function test_can_serialize_to_string_with_strict_type_checking()
+    {
+        $rule = new EnumValue(UserType::class, true);
+        
+        $this->assertEquals('enum_value:' . UserType::class . ',true', (string) $rule);
+    }
 }


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] **N/A:** Added or updated the [README.md](../README.md)

**Related Issue/Intent**

Occasionally its necessary to serialize Laravel rules to a string. This adds `__toString` serialization to both `EnumKey` and `EnumValue` (see `Illuminate\Validation\Rules\In` for an example inside of Laravel).

**Changes**

This simply adds `__toString` to both provided rules.

**Breaking changes**

N/A
