### PR TITLE
Autoinstall through https://github.com/phpstan/extension-installer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,6 +54,11 @@
             "providers": [
                 "BenSampo\\Enum\\EnumServiceProvider"
             ]
+        },
+        "phpstan": {
+            "includes": [
+                "extension.neon"
+            ]
         }
     },
     "config": {


### PR DESCRIPTION
This enables users of `phpstan/extension-installer` to automatically register the extension provided by `laravel-enum`.

Just like Laravel's automatic package registration, this provides extra convencience.