### PR TITLE
Update setAttribute to return the parent method

### DIFF
--- a/src/Traits/CastsEnums.php
+++ b/src/Traits/CastsEnums.php
@@ -51,7 +51,7 @@ trait CastsEnums
             return $this;
         }
 
-        parent::setAttribute($key, $value);
+        return parent::setAttribute($key, $value);
     }
 
     /**


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Added or updated the [README.md](../README.md)

**Related Issue/Intent**

N/A

**Changes**

Returns the model when using `setAttribute`. Currently, it doesn't return the model if the attribute doesn't have a enum cast which breaks the intended behaviour of Eloquent. This fix simply returns the call to the `setAttribute` on the parent.

**Breaking changes**

N/A
