### PR TITLE
Use static|null

### DIFF
--- a/src/Enum.php
+++ b/src/Enum.php
@@ -170,7 +170,7 @@ abstract class Enum implements EnumContract
      * Attempt to instantiate a new Enum using the given value if it exists.
      *
      * @param  mixed  $enumValue
-     * @return ?Enum
+     * @return static|null
      */
     public static function coerce($enumValue): ?self
     {


### PR DESCRIPTION
- [n/a] Added or updated tests
- [n/a] Added or updated the [README.md](../README.md)

**Related Issue/Intent**

This fixes a warning in some IDEs about returning an Enum rather than the actual class type

**Changes**

IDEs no longer warn about return of type Enum
