### PR TITLE
Adding assert function as alias of getInstance

### DIFF
--- a/src/Enum.php
+++ b/src/Enum.php
@@ -141,6 +141,7 @@ abstract class Enum implements EnumContract
      *
      * @param  mixed  $enumValue
      * @return static
+     * @throws InvalidEnumMemberException
      */
     public static function getInstance($enumValue): self
     {
@@ -164,6 +165,18 @@ abstract class Enum implements EnumContract
             },
             static::getConstants()
         );
+    }
+
+    /**
+     * Return a new Enum instance or throw InvalidEnumMemberException
+     *
+     * @param  string  $enumValue
+     * @return static
+     * @throws InvalidEnumMemberException
+     */
+    public static function assert($enumValue): self
+    {
+        return static::getInstance($enumValue);
     }
 
     /**

--- a/tests/EnumAssertTest.php
+++ b/tests/EnumAssertTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace BenSampo\Enum\Tests;
+
+use PHPUnit\Framework\TestCase;
+use BenSampo\Enum\Tests\Enums\UserType;
+use BenSampo\Enum\Tests\Enums\StringValues;
+use BenSampo\Enum\Exceptions\InvalidEnumMemberException;
+
+class EnumAssertTest extends TestCase
+{
+    public function test_can_instantiate_enum_class()
+    {
+        $userType = UserType::assert(UserType::Administrator);
+        $this->assertInstanceOf(UserType::class, $userType);
+
+        $stringValues = new StringValues(StringValues::Moderator);
+        $this->assertInstanceOf(StringValues::class, $stringValues);
+    }
+
+    public function test_an_exception_is_thrown_when_trying_to_instantiate_enum_class_with_an_invalid_enum_value()
+    {
+        $this->expectException(InvalidEnumMemberException::class);
+
+        UserType::assert('InvalidValue');
+    }
+
+    public function test_can_get_the_value_for_an_enum_instance()
+    {
+        $userType = UserType::assert(UserType::Administrator);
+
+        $this->assertEquals($userType->value, UserType::Administrator);
+    }
+
+    public function test_can_get_the_key_for_an_enum_instance()
+    {
+        $userType = UserType::assert(UserType::Administrator);
+
+        $this->assertEquals($userType->key, UserType::getKey(UserType::Administrator));
+    }
+
+    public function test_can_get_the_description_for_an_enum_instance()
+    {
+        $userType = UserType::assert(UserType::Administrator);
+
+        $this->assertEquals($userType->description, UserType::getDescription(UserType::Administrator));
+    }
+}

--- a/tests/Enums/MixedKeyFormatsAnnotated.php
+++ b/tests/Enums/MixedKeyFormatsAnnotated.php
@@ -11,6 +11,13 @@ use BenSampo\Enum\Enum;
  * @method static static UPPERCASE_SNAKE_CASE()
  * @method static static lowercase_snake_case()
  */
+/**
+ * @method static static Normal()
+ * @method static static MultiWordKeyName()
+ * @method static static UPPERCASE()
+ * @method static static UPPERCASE_SNAKE_CASE()
+ * @method static static lowercase_snake_case()
+ */
 final class MixedKeyFormatsAnnotated extends Enum
 {
     const Normal = 1;

--- a/tests/Models/AnnotatedExample.php
+++ b/tests/Models/AnnotatedExample.php
@@ -12,6 +12,12 @@ use Illuminate\Database\Eloquent\Model;
  * @property \BenSampo\Enum\Tests\Enums\UserType|null $user_type
  * @see https://github.com/BenSampo/laravel-enum/pull/71
  */
+/**
+ * Description should be kept
+ *
+ * @property \BenSampo\Enum\Tests\Enums\UserType|null $user_type
+ * @see https://github.com/BenSampo/laravel-enum/pull/71
+ */
 class AnnotatedExample extends Model
 {
     use CastsEnums;


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Added or updated the [README.md](../README.md)

**Related Issue/Intent**

Created a new function assert that is just an alias of getInstance as a complimentary name to coerce. This is a convenience when passing values from external sources to make it visually clearer that this function will throw for unexpected inputs

**Changes**

Assert is identical to getInstance. Added at test to make sure asserts expected functionality does not change if getInstance were to change.
