### PR TITLE
Changed the InvalidEnumMemberException to accept a class string as well, instead of only an Enum instance

### DIFF
--- a/src/Exceptions/InvalidEnumMemberException.php
+++ b/src/Exceptions/InvalidEnumMemberException.php
@@ -11,10 +11,10 @@ class InvalidEnumMemberException extends Exception
      * Create an InvalidEnumMemberException.
      *
      * @param  mixed  $invalidValue
-     * @param  \BenSampo\Enum\Enum  $enum
+     * @param  \BenSampo\Enum\Enum|string  $enum
      * @return void
      */
-    public function __construct($invalidValue, Enum $enum)
+    public function __construct($invalidValue, $enum)
     {
         $invalidValueType = gettype($invalidValue);
         $enumValues = implode(', ', $enum::getValues());


### PR DESCRIPTION
- [ ] Added or updated tests
- [ ] Added or updated the [README.md](../README.md) - Not Applicable

**Related Issue/Intent**

Current behaviour caused the InvalidEnumMemberException to not be throwable outside the Enum constructor

**Changes**

The InvalidEnumMemberException now also accepts class strings

**Breaking changes**

None, unless someone depended on the TypeError being thrown
