### PR TITLE
Implement __set_state Magic Methods to allow use of Enums in Laravel …

### DIFF
--- a/src/Enum.php
+++ b/src/Enum.php
@@ -185,7 +185,7 @@ abstract class Enum implements EnumContract
         if (is_string($enumKeyOrValue) && static::hasKey($enumKeyOrValue)) {
             return static::$enumKeyOrValue();
         }
-        
+
         return null;
     }
 
@@ -410,5 +410,16 @@ abstract class Enum implements EnumContract
     public static function getLocalizationKey(): string
     {
         return 'enums.' . static::class;
+    }
+
+    /**
+     * This static method is called for classes exported by var_export()
+     *
+     * @param $an_array
+     * @return array
+     */
+    public static function __set_state($an_array)
+    {
+        return static::getInstance($an_array['value']);
     }
 }


### PR DESCRIPTION
…config files with the ```php artisan config:cache``` command.

- [n/a] Added or updated tests
- [n/a] Added or updated the [README.md](../README.md)

**Related Issue/Intent**

Allows use of Enums in laravel config files when ```php artisan config:cache``` is used in deploy
Fixes 'Your configuration files are not serializable.' issues when an Enum class is used in a laravel config file when calling ```php artisan config:cache```

**Changes**

Implements __set_state Magic Method

