### PR TITLE
Handle missing $enumCasts property gracefully in CastsEnums

### DIFF
--- a/src/Traits/CastsEnums.php
+++ b/src/Traits/CastsEnums.php
@@ -62,6 +62,12 @@ trait CastsEnums
      */
     public function hasEnumCast($key): bool
     {
+        // This can happen if this trait is added to the model
+        // but no enum casts have been added yet
+        if ($this->enumCasts === null) {
+            return false;
+        }
+
         return array_key_exists($key, $this->enumCasts);
     }
 

--- a/tests/EnumCastTest.php
+++ b/tests/EnumCastTest.php
@@ -2,6 +2,7 @@
 
 namespace BenSampo\Enum\Tests;
 
+use BenSampo\Enum\Tests\Models\WithTraitButNoCasts;
 use PHPUnit\Framework\TestCase;
 use BenSampo\Enum\Tests\Enums\UserType;
 use BenSampo\Enum\Tests\Models\Example;
@@ -63,5 +64,12 @@ class EnumCastTest extends TestCase
         $model->user_type = UserType::Moderator();
 
         $this->assertSame(['user_type' => 1], $model->toArray());
+    }
+
+    public function test_model_with_trait_but_no_casts()
+    {
+        $model = app(WithTraitButNoCasts::class);
+        $model->foo = true;
+        $this->assertTrue($model->foo);
     }
 }

--- a/tests/Models/WithTraitButNoCasts.php
+++ b/tests/Models/WithTraitButNoCasts.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace BenSampo\Enum\Tests\Models;
+
+use BenSampo\Enum\Traits\CastsEnums;
+use Illuminate\Database\Eloquent\Model;
+
+class WithTraitButNoCasts extends Model
+{
+    use CastsEnums;
+}


### PR DESCRIPTION
- [x] Added or updated tests
~~- [ ] Added or updated the [README.md](../README.md)~~

**Related Issue/Intent**

When adding the `CastsEnum` trait but not adding `$castsEnums` yet, the following error is thrown:

```
1) BenSampo\Enum\Tests\EnumCastTest::test_model_with_trait_but_no_casts
array_key_exists() expects parameter 2 to be array, null given

/projects/laravel-enum/src/Traits/CastsEnums.php:66
/projects/laravel-enum/src/Traits/CastsEnums.php:39
/projects/laravel-enum/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Model.php:1535
/projects/laravel-enum/tests/EnumCastTest.php:72
```

This is confusing and can be a nuisance when adding/removing enum casts when refactoring.

**Changes**

Handle unset `$enumCasts` gracefully.

**Breaking changes**

None.
