### PR TITLE
Fix compatibility with PHPStan 0.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+
+### Changed
+
+- Add compatibility with PHPStan `0.12.x` 

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "doctrine/dbal": "^2.9",
         "laravel/framework": "5.6.*|5.7.*|5.8.*|^6.0",
         "orchestra/testbench": "3.6.*|3.7.*|3.8.*|3.9.*|^4.0",
-        "phpstan/phpstan": "^0.11.6",
+        "phpstan/phpstan": "^0.12.8",
         "phpunit/phpunit": "^7.5|^8.5",
         "squizlabs/php_codesniffer": "^3.0"
     },

--- a/src/PHPStan/EnumMethodReflection.php
+++ b/src/PHPStan/EnumMethodReflection.php
@@ -6,6 +6,7 @@ use PHPStan\Reflection\ClassMemberReflection;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\FunctionVariant;
 use PHPStan\Reflection\MethodReflection;
+use PHPStan\TrinaryLogic;
 use PHPStan\Type\ObjectType;
 
 class EnumMethodReflection implements MethodReflection
@@ -65,5 +66,40 @@ class EnumMethodReflection implements MethodReflection
                 new ObjectType($this->classReflection->getName())
             ),
         ];
+    }
+
+    public function getDocComment(): ?string
+    {
+        return null;
+    }
+
+    public function isDeprecated(): \PHPStan\TrinaryLogic
+    {
+        return TrinaryLogic::createNo();
+    }
+
+    public function getDeprecatedDescription(): ?string
+    {
+        return null;
+    }
+
+    public function isFinal(): \PHPStan\TrinaryLogic
+    {
+        return TrinaryLogic::createNo();
+    }
+
+    public function isInternal(): \PHPStan\TrinaryLogic
+    {
+        return TrinaryLogic::createNo();
+    }
+
+    public function getThrowType(): ?\PHPStan\Type\Type
+    {
+        return null;
+    }
+
+    public function hasSideEffects(): \PHPStan\TrinaryLogic
+    {
+        return TrinaryLogic::createNo();
     }
 }

--- a/src/PHPStan/EnumMethodReflection.php
+++ b/src/PHPStan/EnumMethodReflection.php
@@ -7,6 +7,7 @@ use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\FunctionVariant;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\TrinaryLogic;
+use PHPStan\Type\Generic\TemplateTypeMap;
 use PHPStan\Type\ObjectType;
 
 class EnumMethodReflection implements MethodReflection
@@ -61,6 +62,8 @@ class EnumMethodReflection implements MethodReflection
     {
         return [
             new FunctionVariant(
+                TemplateTypeMap::createEmpty(),
+                null,
                 [],
                 false,
                 new ObjectType($this->classReflection->getName())


### PR DESCRIPTION
~~- [ ] Added or updated tests~~
~~- [ ] Added or updated the [README.md](../README.md)~~

**Changes**

Adapt `\BenSampo\Enum\PHPStan\EnumMethodReflection` to work with PHPStan 0.12, they added some new methods to the interface.

I also started a `CHANGELOG.md`, i found it to be a great way to inform users about updates in the package.

**Breaking changes**

Actually no, the changes are additive and still work with PHPStan 0.11