### PR TITLE
Fix for Lumen when Facade not set

### DIFF
--- a/src/EnumServiceProvider.php
+++ b/src/EnumServiceProvider.php
@@ -48,13 +48,13 @@ class EnumServiceProvider extends ServiceProvider
      */
     private function bootValidators()
     {
-        Validator::extend('enum_key', function ($attribute, $value, $parameters, $validator) {
+        $this->app['validator']->extend('enum_key', function ($attribute, $value, $parameters, $validator) {
             $enum = $parameters[0] ?? null;
 
             return (new EnumKey($enum))->passes($attribute, $value);
         });
 
-        Validator::extend('enum_value', function ($attribute, $value, $parameters, $validator) {
+        $this->app['validator']->extend('enum_value', function ($attribute, $value, $parameters, $validator) {
             $enum = $parameters[0] ?? null;
 
             $strict = $parameters[1] ?? null;


### PR DESCRIPTION
Fix RuntimeException : A facade root has not been set.

- [x] Added or updated tests
- [x] Added or updated the [README.md](../README.md)
- [x] Detailed changes in the [CHANGELOG.md](../CHANGELOG.md) unreleased section

**Related Issue/Intent**
Resolves #118 giving ability to use in Lumen

**Changes**
Replace Facade Validator to build-in.

**Breaking changes**
none