### PR TITLE
Change order of `value` and `key` attribute inside Enum class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Change order of attributes in `BenSampo\Enum\Enum`, to ensure relational comparison (with <,>) uses the $value attribute. (Ref: https://www.php.net/manual/en/language.oop5.object-comparison.php#98725)
 
 ## [1.33.0](https://github.com/BenSampo/laravel-enum/compare/v1.32...v1.33) - 2020-03-05
 

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -18,18 +18,18 @@ abstract class Enum implements EnumContract
     }
 
     /**
-     * The key of one of the enum members.
-     *
-     * @var mixed
-     */
-    public $key;
-
-    /**
      * The value of one of the enum members.
      *
      * @var mixed
      */
     public $value;
+
+    /**
+     * The key of one of the enum members.
+     *
+     * @var mixed
+     */
+    public $key;
 
     /**
      * The description of one of the enum members.
@@ -116,7 +116,7 @@ abstract class Enum implements EnumContract
      */
     public function isNot($enumValue): bool
     {
-        return ! $this->is($enumValue);
+        return !$this->is($enumValue);
     }
 
     /**
@@ -185,7 +185,7 @@ abstract class Enum implements EnumContract
         if (is_string($enumKeyOrValue) && static::hasKey($enumKeyOrValue)) {
             return static::$enumKeyOrValue();
         }
-        
+
         return null;
     }
 

--- a/tests/EnumComparisonTest.php
+++ b/tests/EnumComparisonTest.php
@@ -65,12 +65,19 @@ class EnumComparisonTest extends TestCase
         $this->assertFalse($administrator->in([StringValues::Moderator]));
     }
 
-    public function test_object_relational_comparision()
+    /**
+     * @test
+     * Verify that relational comparision of Enum object uses attribute `$value`
+     * 
+     * "comparison operation stops and returns at the first unequal property found."
+     * as stated in https://www.php.net/manual/en/language.oop5.object-comparison.php#98725
+     * @return void
+     */
+    public function test_object_relational_comparison()
     {
-        $z = IntegerValues::Z();
-        $y = IntegerValues::Y();
-        $x = IntegerValues::X();
+        $b = IntegerValues::B();
+        $a = IntegerValues::A();
 
-        $this->assertEquals($z, min($x, $y, $z));
+        $this->assertTrue($a > $b);
     }
 }

--- a/tests/EnumComparisonTest.php
+++ b/tests/EnumComparisonTest.php
@@ -2,6 +2,7 @@
 
 namespace BenSampo\Enum\Tests;
 
+use BenSampo\Enum\Tests\Enums\IntegerValues;
 use BenSampo\Enum\Tests\Enums\StringValues;
 use BenSampo\Enum\Tests\Enums\UserType;
 use PHPUnit\Framework\TestCase;
@@ -62,5 +63,14 @@ class EnumComparisonTest extends TestCase
         ]));
         $this->assertTrue($administrator->in([StringValues::Administrator]));
         $this->assertFalse($administrator->in([StringValues::Moderator]));
+    }
+
+    public function test_object_relational_comparision()
+    {
+        $z = IntegerValues::Z();
+        $y = IntegerValues::Y();
+        $x = IntegerValues::X();
+
+        $this->assertEquals($z, min($x, $y, $z));
     }
 }

--- a/tests/Enums/IntegerValues.php
+++ b/tests/Enums/IntegerValues.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace BenSampo\Enum\Tests\Enums;
+
+use BenSampo\Enum\Enum;
+
+final class IntegerValues extends Enum
+{
+    const Z = 1;
+    const Y = 2;
+    const X = 3;
+}

--- a/tests/Enums/IntegerValues.php
+++ b/tests/Enums/IntegerValues.php
@@ -6,7 +6,6 @@ use BenSampo\Enum\Enum;
 
 final class IntegerValues extends Enum
 {
-    const Z = 1;
-    const Y = 2;
-    const X = 3;
+    const B = 1;
+    const A = 2;
 }


### PR DESCRIPTION
**Related Issue/Intent**

Resolves #128 

**Changes**

Change order of `value` and `key` attribute inside Enum class
Making this change enables relational comparison (using <, >) according to
https://www.php.net/manual/en/language.oop5.object-comparison.php#98725

**Breaking changes**

none

- [x] Added or updated tests
- [x] Detailed changes in the [CHANGELOG.md](../CHANGELOG.md) unreleased section
