### PR TITLE
Laravel 7 native casts

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,7 +442,7 @@ $example->user_type = UserType::Moderator();
 ### Casting underlying native types
 Many databases return everything as strings (for example, an integer may be returned as the string `'1'`).
 To reduce friction for users of the library, we use type coercion to
-figure out the intended value. If you'd prefer to control this, you can override the `castNative` static method on your enum class:
+figure out the intended value. If you'd prefer to control this, you can override the `parseDatabase` static method on your enum class:
 
 ```php
 final class UserType extends Enum
@@ -450,7 +450,7 @@ final class UserType extends Enum
     const Administrator = 0;
     const Moderator = 1;
     
-    public static function castNative($value)
+    public static function parseDatabase($value)
     {
         return (int) $value;
     }

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Created by [Ben Sampson](https://sampo.co.uk)
 
 ## Documentation for v1
 You are reading the documentation for `2.x`. If you're using Laravel 6 or below, please see the docs for `1.x`.
+Please see the [upgrade guide](./UPGRADE.md) for information on how to upgrade from `1.x`.
 
 ## Guide
 
@@ -453,21 +454,6 @@ final class UserType extends Enum
         return (int) $value;
     }
 }
-```
-
-### Upgrading from Laravel Enum 1.x
-If you're upgrading from `1.x`, then you should update your models to use Laravel 7 native casting. Remove the trait and
-move the casts from `$enumCasts` to `$casts`. 
-
-```diff
-class MyModel extends Model
-{
--   use CastsEnums;
-
--   protected $enumCasts = [
-+   protected $casts = [
-        'foo' => Foo::class,
-    ];
 ```
 
 ### Model Annotation

--- a/README.md
+++ b/README.md
@@ -45,27 +45,25 @@ Created by [Ben Sampson](https://sampo.co.uk)
 * [Artisan Command List](#artisan-command-list)
 * [Enum Class Reference](#enum-class-reference)
 
+## Documentation for v1
+You are reading the documentation for `2.x`. If you're using Laravel 6 or below, please see the docs for `1.x`.
+
 ## Guide
 
 I wrote a blog post about using laravel-enum: https://sampo.co.uk/blog/using-enums-in-laravel
 
-## Requirements
-
-- Laravel `5.4` or newer  
-- PHP `7.1` or newer
-
 ## Installation
+
+### Requirements
+
+- Laravel `7.5` or newer  
+- PHP `7.2.5` or newer
+
 
 Via Composer
 
 ```bash
 composer require bensampo/laravel-enum
-```
-
-If you're using Laravel < 5.5 you'll need to add the service provider to `config/app.php`
-
-```php
-'BenSampo\Enum\EnumServiceProvider'
 ```
 
 ## Enum Library
@@ -399,9 +397,8 @@ UserPermissions::DeleteComments()->getBitmask(); // 1000;
 
 ## Attribute Casting
 
-You may cast model attributes to enums using the `CastsEnums` trait. This will cast the attribute to an enum instance when getting and back to the enum value when setting.
-
-Similar to how standard attribute casting works, you simply define which attributes you want to cast to which enum as an array on the model.
+You may cast model attributes to enums using Laravel 7.x's built in custom casting. This will cast the attribute to an enum instance when getting and back to the enum value when setting.
+Since `Enum::class` implements the `Castable` contract, you just need to specify the classname of the enum:
 
 ```php
 use BenSampo\Enum\Traits\CastsEnums;
@@ -412,17 +409,9 @@ class Example extends Model
 {
     use CastsEnums;
 
-    protected $enumCasts = [
-        // 'attribute_name' => Enum::class
-        'user_type' => UserType::class,
-    ];
-
-    /**
-     * Existing casts are processed before $enumCasts which can be useful if you're 
-     * taking input from forms and your enum values are integers.
-     */
     protected $casts = [
-        'user_type' => 'int',
+        'random_flag' => 'boolean',     // Example standard laravel cast
+        'user_type' => UserType::class, // Example enum cast
     ];
 }
 ```
@@ -447,6 +436,38 @@ $example->user_type = UserType::Moderator;
 
 // Set using enum instance
 $example->user_type = UserType::Moderator();
+```
+
+### Casting underlying native types
+Many databases return everything as strings (for example, an integer may be returned as the string `'1'`). To reduce fricton for users of the library we'll use type coercion to
+figure out the intended value. If you'd prefer to control this, you can override the `castNative` static method on your enum class:
+
+```php
+final class UserType extends Enum
+{
+    const Administrator = 0;
+    const Moderator = 1;
+    
+    public static function castNative($value)
+    {
+        return (int) $value;
+    }
+}
+```
+
+### Upgrading from Laravel Enum 1.x
+If you're upgrading from `1.x`, then you should update your models to use Laravel 7 native casting. Remove the trait and
+move the casts from `$enumCasts` to `$casts`. 
+
+```diff
+class MyModel extends Model
+{
+-   use CastsEnums;
+
+-   protected $enumCasts = [
++   protected $casts = [
+        'foo' => Foo::class,
+    ];
 ```
 
 ### Model Annotation

--- a/README.md
+++ b/README.md
@@ -440,7 +440,8 @@ $example->user_type = UserType::Moderator();
 ```
 
 ### Casting underlying native types
-Many databases return everything as strings (for example, an integer may be returned as the string `'1'`). To reduce fricton for users of the library we'll use type coercion to
+Many databases return everything as strings (for example, an integer may be returned as the string `'1'`).
+To reduce friction for users of the library, we use type coercion to
 figure out the intended value. If you'd prefer to control this, you can override the `castNative` static method on your enum class:
 
 ```php

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -14,8 +14,12 @@ move the casts from `$enumCasts` to `$casts`.
 Trait based casting is still present, but is now deprecated and will be removed in the next major version.
 
 ```diff
+--use BenSampo\Enum\Traits\CastsEnums;
+
 class MyModel extends Model
 {
+-   use CastsEnums;
+
 -   protected $enumCasts = [
 +   protected $casts = [
         'foo' => Foo::class,

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,0 +1,23 @@
+# Upgrade Guide
+
+## 2.x
+
+### Laravel 7 Required
+`2.x` uses new features not present in earlier laravel versions, so Laravel 7 is required.
+PHP `7.2.5` or greater is also now required.
+
+### Switch to native casting
+
+You should update your models to use Laravel 7 native casting. Remove the trait and
+move the casts from `$enumCasts` to `$casts`. 
+
+Trait based casting is still present, but is now deprecated and will be removed in the next major version.
+
+```diff
+class MyModel extends Model
+{
+-   protected $enumCasts = [
++   protected $casts = [
+        'foo' => Foo::class,
+    ];
+```

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
         "php": "^7.2.5",
         "hanneskod/classtools": "~1.0",
         "illuminate/support": "^7.5",
+        "illuminate/contracts": "^7.5",
         "laminas/laminas-code": "^3.4"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -19,17 +19,17 @@
         }
     ],
     "require": {
-        "php": "~7.1",
+        "php": "~7.2.5",
         "hanneskod/classtools": "~1.0",
-        "illuminate/support": "5.4.*|5.5.*|5.6.*|5.7.*|5.8.*|^6.0|^7.0",
+        "illuminate/support": "^7.4",
         "laminas/laminas-code": "^3.4"
     },
     "require-dev": {
         "doctrine/dbal": "^2.9",
-        "laravel/framework": "5.6.*|5.7.*|5.8.*|^6.0|^7.0",
-        "orchestra/testbench": "3.6.*|3.7.*|3.8.*|3.9.*|^4.0|^5.0",
+        "laravel/framework": "^7.5",
+        "orchestra/testbench": "^5.0",
         "phpstan/phpstan": "^0.12.9",
-        "phpunit/phpunit": "^7.5|^8.5",
+        "phpunit/phpunit": "^8.5",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "php": "~7.2.5",
+        "php": "^7.2.5",
         "hanneskod/classtools": "~1.0",
         "illuminate/support": "^7.5",
         "laminas/laminas-code": "^3.4"

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "require": {
         "php": "~7.2.5",
         "hanneskod/classtools": "~1.0",
-        "illuminate/support": "^7.4",
+        "illuminate/support": "^7.5",
         "laminas/laminas-code": "^3.4"
     },
     "require-dev": {

--- a/src/Casts/EnumCast.php
+++ b/src/Casts/EnumCast.php
@@ -31,7 +31,7 @@ class EnumCast implements CastsAttributes
     {
         $value = $this->castEnum($value);
 
-        return [$key => $value->value];
+        return [$key => $this->enumClass::serializeDatabase($value)];
     }
 
     /**
@@ -60,7 +60,7 @@ class EnumCast implements CastsAttributes
     protected function getCastableValue($value)
     {
         // If the enum has overridden the `castNative` method, use it to get the cast value
-        $value = $this->enumClass::castNative($value);
+        $value = $this->enumClass::parseDatabase($value);
 
         // If the value exists in the enum (using strict type checking) return it
         if ($this->enumClass::hasValue($value)) {

--- a/src/Casts/EnumCast.php
+++ b/src/Casts/EnumCast.php
@@ -11,9 +11,13 @@ class EnumCast implements CastsAttributes
     /**@var string */
     private $enumClass;
 
-    public function __construct(string $enumClass)
+    /** @var string|null */
+    private $nativeType;
+
+    public function __construct(string $enumClass, ?string $nativeType = null)
     {
         $this->enumClass = $enumClass;
+        $this->nativeType = $nativeType;
     }
 
     /**
@@ -55,6 +59,30 @@ class EnumCast implements CastsAttributes
             return $value;
         }
 
+        if ($this->nativeType !== null) {
+            $value = $this->performNativeCast($value);
+        }
+
         return $enum::getInstance($value);
+    }
+
+    protected function performNativeCast($value)
+    {
+        switch ($this->nativeType) {
+            case 'int':
+            case 'integer':
+                return (int) $value;
+            case 'real':
+            case 'float':
+            case 'double':
+                return (float) $value;
+            case 'string':
+                return (string) $value;
+            case 'bool':
+            case 'boolean':
+                return (bool) $value;
+        }
+
+        return $value;
     }
 }

--- a/src/Casts/EnumCast.php
+++ b/src/Casts/EnumCast.php
@@ -1,0 +1,60 @@
+<?php
+declare(strict_types=1);
+
+namespace BenSampo\Enum\Casts;
+
+use BenSampo\Enum\Enum;
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+
+class EnumCast implements CastsAttributes
+{
+    /**@var string */
+    private $enumClass;
+
+    public function __construct(string $enumClass)
+    {
+        $this->enumClass = $enumClass;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function get($model, string $key, $value, array $attributes)
+    {
+        return $this->castEnum($value);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function set($model, string $key, $value, array $attributes)
+    {
+        if ($value === null) {
+            return $value;
+        }
+
+        $enum = $this->enumClass;
+
+        if (!$value instanceof $enum) {
+            $value = $this->castEnum($value);
+        }
+
+        return [$key => $value->value];
+    }
+
+    /**
+     * @param mixed $value
+     *
+     * @return Enum|null
+     */
+    protected function castEnum($value): ?Enum
+    {
+        $enum = $this->enumClass;
+
+        if ($value === null || $value instanceof Enum) {
+            return $value;
+        }
+
+        return $enum::getInstance($value);
+    }
+}

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -2,15 +2,17 @@
 
 namespace BenSampo\Enum;
 
+use BenSampo\Enum\Casts\EnumCast;
 use BenSampo\Enum\Contracts\EnumContract;
 use BenSampo\Enum\Contracts\LocalizedEnum;
 use BenSampo\Enum\Exceptions\InvalidEnumMemberException;
+use Illuminate\Contracts\Database\Eloquent\Castable;
 use Illuminate\Support\Facades\Lang;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
 use ReflectionClass;
 
-abstract class Enum implements EnumContract
+abstract class Enum implements EnumContract, Castable
 {
     use Macroable {
         // Because this class also defines a '__callStatic' method, a new name has to be given to the trait's '__callStatic' method.
@@ -410,5 +412,16 @@ abstract class Enum implements EnumContract
     public static function getLocalizationKey(): string
     {
         return 'enums.' . static::class;
+    }
+
+    public static function castUsing()
+    {
+        $nativeType = null;
+
+        if (property_exists(get_called_class(), 'nativeType')) {
+            $nativeType = static::$nativeType;
+        }
+
+        return new EnumCast(static::class, $nativeType);
     }
 }

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -415,7 +415,7 @@ abstract class Enum implements EnumContract, Castable
     }
 
     /**
-     * Cast values before constructing an enum from them.
+     * Cast values loaded from the database before constructing an enum from them.
      *
      * You may need to overwrite this when using string values that are returned
      * from a raw database query or a similar data source.
@@ -423,7 +423,21 @@ abstract class Enum implements EnumContract, Castable
      * @param  mixed  $value  A raw value that may have any native type
      * @return mixed  The value cast into the type this enum expects
      */
-    public static function castNative($value)
+    public static function parseDatabase($value)
+    {
+        return $value;
+    }
+
+    /**
+     * Transform value from the enum instance before it's persisted to the database.
+     *
+     * You may need to overwrite this when using a database that expects a different
+     * type to that used internally in your enum.
+     *
+     * @param  mixed  $value  A raw value that may have any native type
+     * @return mixed  The value cast into the type this database expects
+     */
+    public static function serializeDatabase($value)
     {
         return $value;
     }

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -7,6 +7,7 @@ use BenSampo\Enum\Contracts\EnumContract;
 use BenSampo\Enum\Contracts\LocalizedEnum;
 use BenSampo\Enum\Exceptions\InvalidEnumMemberException;
 use Illuminate\Contracts\Database\Eloquent\Castable;
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
 use Illuminate\Support\Facades\Lang;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
@@ -442,7 +443,7 @@ abstract class Enum implements EnumContract, Castable
         return $value;
     }
 
-    public static function castUsing()
+    public static function castUsing(): CastsAttributes
     {
         return new EnumCast(static::class);
     }

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -414,14 +414,22 @@ abstract class Enum implements EnumContract, Castable
         return 'enums.' . static::class;
     }
 
+    /**
+     * Cast values before constructing an enum from them.
+     *
+     * You may need to overwrite this when using string values that are returned
+     * from a raw database query or a similar data source.
+     *
+     * @param  mixed  $value  A raw value that may have any native type
+     * @return mixed  The value cast into the type this enum expects
+     */
+    public static function castNative($value)
+    {
+        return $value;
+    }
+
     public static function castUsing()
     {
-        $nativeType = null;
-
-        if (property_exists(get_called_class(), 'nativeType')) {
-            $nativeType = static::$nativeType;
-        }
-
-        return new EnumCast(static::class, $nativeType);
+        return new EnumCast(static::class);
     }
 }

--- a/tests/Enums/UserType.php
+++ b/tests/Enums/UserType.php
@@ -6,6 +6,8 @@ use BenSampo\Enum\Enum;
 
 final class UserType extends Enum
 {
+    protected static $nativeType = 'integer';
+
     const Administrator = 0;
     const Moderator = 1;
     const Subscriber = 2;

--- a/tests/Enums/UserType.php
+++ b/tests/Enums/UserType.php
@@ -6,8 +6,6 @@ use BenSampo\Enum\Enum;
 
 final class UserType extends Enum
 {
-    protected static $nativeType = 'integer';
-
     const Administrator = 0;
     const Moderator = 1;
     const Subscriber = 2;

--- a/tests/Enums/UserTypeCustomCast.php
+++ b/tests/Enums/UserTypeCustomCast.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace BenSampo\Enum\Tests\Enums;
+
+use BenSampo\Enum\Enum;
+
+final class UserTypeCustomCast extends Enum
+{
+    const Administrator = 0;
+    const Moderator = 1;
+    const Subscriber = 2;
+    const SuperAdministrator = 3;
+
+    public static function parseDatabase($value)
+    {
+        return explode('-', $value)[1] ?? null;
+    }
+
+    public static function serializeDatabase($value)
+    {
+        return 'type-' . $value;
+    }
+}

--- a/tests/Models/NativeCastModel.php
+++ b/tests/Models/NativeCastModel.php
@@ -9,7 +9,7 @@ use Illuminate\Database\Eloquent\Model;
 class NativeCastModel extends Model
 {
     protected $casts = [
-        'user_type' => EnumCast::class . ':' . UserType::class,
+        'user_type' => UserType::class,
     ];
 
     protected $fillable = [

--- a/tests/Models/NativeCastModel.php
+++ b/tests/Models/NativeCastModel.php
@@ -4,15 +4,18 @@ namespace BenSampo\Enum\Tests\Models;
 
 use BenSampo\Enum\Casts\EnumCast;
 use BenSampo\Enum\Tests\Enums\UserType;
+use BenSampo\Enum\Tests\Enums\UserTypeCustomCast;
 use Illuminate\Database\Eloquent\Model;
 
 class NativeCastModel extends Model
 {
     protected $casts = [
         'user_type' => UserType::class,
+        'user_type_custom' => UserTypeCustomCast::class,
     ];
 
     protected $fillable = [
         'user_type',
+        'user_type_custom',
     ];
 }

--- a/tests/Models/NativeCastModel.php
+++ b/tests/Models/NativeCastModel.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace BenSampo\Enum\Tests\Models;
+
+use BenSampo\Enum\Casts\EnumCast;
+use BenSampo\Enum\Tests\Enums\UserType;
+use Illuminate\Database\Eloquent\Model;
+
+class NativeCastModel extends Model
+{
+    protected $casts = [
+        'user_type' => EnumCast::class . ':' . UserType::class,
+    ];
+
+    protected $fillable = [
+        'user_type',
+    ];
+}

--- a/tests/NativeEnumCastTest.php
+++ b/tests/NativeEnumCastTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace BenSampo\Enum\Tests;
+
+use BenSampo\Enum\Exceptions\InvalidEnumMemberException;
+use BenSampo\Enum\Tests\Enums\UserType;
+use BenSampo\Enum\Tests\Models\NativeCastModel;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+
+class NativeEnumCastTest extends TestCase
+{
+    public function test_can_set_model_value_using_enum_instance()
+    {
+        $model = app(NativeCastModel::class);
+        $model->user_type = UserType::Moderator();
+
+        $this->assertEquals(UserType::Moderator(), $model->user_type);
+    }
+
+    public function test_can_set_model_value_using_enum_value()
+    {
+        $model = app(NativeCastModel::class);
+        $model->user_type = UserType::Moderator;
+
+        $this->assertEquals(UserType::Moderator(), $model->user_type);
+    }
+
+    public function test_cannot_set_model_value_using_invalid_enum_value()
+    {
+        $this->expectException(InvalidEnumMemberException::class);
+
+        $model = app(NativeCastModel::class);
+        $model->user_type = 5;
+    }
+
+    public function test_getting_model_value_returns_enum_instance()
+    {
+        $model = app(NativeCastModel::class);
+        $model->user_type = UserType::Moderator;
+
+        $this->assertInstanceOf(UserType::class, $model->user_type);
+    }
+
+    public function test_can_get_and_set_null_on_enum_castable()
+    {
+        $model = app(NativeCastModel::class);
+        $model->user_type = null;
+
+        $this->assertNull($model->user_type);
+    }
+
+    public function test_can_handle_string_int_from_database()
+    {
+        /** @var NativeCastModel $model */
+        $model = app(NativeCastModel::class);
+
+        $reflection = new \ReflectionProperty(NativeCastModel::class, 'attributes');
+        $reflection->setAccessible(true);
+        $reflection->setValue($model, ['user_type' => '1']);
+
+        $this->assertInstanceOf(UserType::class, $model->user_type);
+    }
+
+    public function test_that_model_with_enum_can_be_cast_to_array()
+    {
+        $model = app(NativeCastModel::class);
+        $model->user_type = UserType::Moderator();
+
+        $this->assertSame(['user_type' => 1], $model->toArray());
+    }
+}

--- a/tests/NativeEnumCastTest.php
+++ b/tests/NativeEnumCastTest.php
@@ -6,7 +6,6 @@ use BenSampo\Enum\Exceptions\InvalidEnumMemberException;
 use BenSampo\Enum\Tests\Enums\UserType;
 use BenSampo\Enum\Tests\Models\NativeCastModel;
 use PHPUnit\Framework\TestCase;
-use ReflectionMethod;
 
 class NativeEnumCastTest extends TestCase
 {
@@ -67,6 +66,12 @@ class NativeEnumCastTest extends TestCase
         $model = app(NativeCastModel::class);
         $model->user_type = UserType::Moderator();
 
-        $this->assertSame(['user_type' => 1], $model->toArray());
+        $this->assertSame([
+            'user_type' => [
+                'value' => 1,
+                'key' => 'Moderator',
+                'description' => 'Moderator',
+            ],
+        ], json_decode(json_encode($model), true));
     }
 }

--- a/tests/NativeEnumCastTest.php
+++ b/tests/NativeEnumCastTest.php
@@ -4,6 +4,7 @@ namespace BenSampo\Enum\Tests;
 
 use BenSampo\Enum\Exceptions\InvalidEnumMemberException;
 use BenSampo\Enum\Tests\Enums\UserType;
+use BenSampo\Enum\Tests\Enums\UserTypeCustomCast;
 use BenSampo\Enum\Tests\Models\NativeCastModel;
 use PHPUnit\Framework\TestCase;
 
@@ -73,5 +74,22 @@ class NativeEnumCastTest extends TestCase
                 'description' => 'Moderator',
             ],
         ], json_decode(json_encode($model), true));
+    }
+
+    public function test_can_use_custom_casting()
+    {
+        /** @var NativeCastModel $model */
+        $model = app(NativeCastModel::class);
+
+        $reflection = new \ReflectionProperty(NativeCastModel::class, 'attributes');
+        $reflection->setAccessible(true);
+        $reflection->setValue($model, ['user_type_custom' => 'type-3']);
+
+        $this->assertInstanceOf(UserTypeCustomCast::class, $model->user_type_custom);
+        $this->assertEquals(UserTypeCustomCast::SuperAdministrator(), $model->user_type_custom);
+
+        $model->user_type_custom = UserTypeCustomCast::Administrator();
+
+        $this->assertSame('type-0', $reflection->getValue($model)['user_type_custom']);
     }
 }


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Added or updated the [README.md](../README.md)
- [x] Detailed changes in the [CHANGELOG.md](../CHANGELOG.md) unreleased section

WIP PR for implementing native eloquent casting.

Current issues:
- ~Currently, we let laravel do native casting, then we apply the enum cast after.~
~Ie. `'6'` cast by laravel -> `6` cast by us -> `EnumInstance`~

~With the new native casts, this isn't possible. I'm thinking we'll need to pass an additional attribute to the constructor to apply a native cast if required.~
~Kind of a bit messy, but not sure if there's a better way?~
Fixed in the latest commit :)


Also, it seems that natively cast attributes are not used in the `toArray()` which is a breaking change, so we need to see if we can return the object.

Edit: also need some way of only running this test on L7 in CI. Should be easy to do via ENV :)