### PR TITLE
EnumValue validation rule allows multiple flags for FlaggedEnums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+- EnumValue validation rule allows multiple flags for FlaggedEnums, integer values only.
 
 ## [1.35.0](https://github.com/BenSampo/laravel-enum/compare/v1.35...v1.36) - 2020-03-22
 

--- a/src/Rules/EnumValue.php
+++ b/src/Rules/EnumValue.php
@@ -48,7 +48,7 @@ class EnumValue implements Rule
      */
     public function passes($attribute, $value)
     {
-        if ($this->enumClass instanceof FlaggedEnum && is_integer($value)) {
+        if (is_subclass_of($this->enumClass, FlaggedEnum::class) && is_integer($value)) {
             // Unset all possible flag values
             foreach($this->enumClass::getValues() as $enumValue) {
                 $value &= ~$enumValue;

--- a/src/Rules/EnumValue.php
+++ b/src/Rules/EnumValue.php
@@ -48,7 +48,7 @@ class EnumValue implements Rule
      */
     public function passes($attribute, $value)
     {
-        if (is_subclass_of($this->enumClass, FlaggedEnum::class) && is_integer($value)) {
+        if (is_subclass_of($this->enumClass, FlaggedEnum::class) && (is_integer($value) || ctype_digit($value))) {
             // Unset all possible flag values
             foreach($this->enumClass::getValues() as $enumValue) {
                 $value &= ~$enumValue;

--- a/src/Rules/EnumValue.php
+++ b/src/Rules/EnumValue.php
@@ -2,6 +2,7 @@
 
 namespace BenSampo\Enum\Rules;
 
+use BenSampo\Enum\FlaggedEnum;
 use Illuminate\Contracts\Validation\Rule;
 
 class EnumValue implements Rule
@@ -47,6 +48,14 @@ class EnumValue implements Rule
      */
     public function passes($attribute, $value)
     {
+        if ($this->enumClass instanceof FlaggedEnum && is_integer($value)) {
+            // Unset all possible flag values
+            foreach($this->enumClass::getValues() as $enumValue) {
+                $value &= ~$enumValue;
+            }
+            // All bits should be unset
+            return $value === 0;
+        }
         return $this->enumClass::hasValue($value, $this->strict);
     }
 

--- a/tests/EnumValueTest.php
+++ b/tests/EnumValueTest.php
@@ -5,6 +5,7 @@ namespace BenSampo\Enum\Tests;
 use PHPUnit\Framework\TestCase;
 use BenSampo\Enum\Rules\EnumValue;
 use BenSampo\Enum\Tests\Enums\UserType;
+use BenSampo\Enum\Tests\Enums\SuperPowers;
 use BenSampo\Enum\Tests\Enums\StringValues;
 
 class EnumValueTest extends TestCase
@@ -27,6 +28,37 @@ class EnumValueTest extends TestCase
         $this->assertFalse($fails1);
         $this->assertFalse($fails2);
         $this->assertFalse($fails3);
+    }
+
+    public function test_flagged_enum_passes_with_no_flags_set()
+    {
+        $passed = (new EnumValue(SuperPowers::class))->passes('', 0);
+
+        $this->assertTrue($passed);
+    }
+
+    public function test_flagged_enum_passes_with_single_flag_set()
+    {
+        $passed = (new EnumValue(SuperPowers::class))->passes('', SuperPowers::Flight);
+
+        $this->assertTrue($passed);
+    }
+
+    public function test_flagged_enum_passes_with_multiple_flags_set()
+    {
+        $passed = (new EnumValue(SuperPowers::class))->passes('', SuperPowers::Superman);
+
+        $this->assertTrue($passed);
+    }
+
+    public function test_flagged_enum_fails_with_invalid_flag_set()
+    {
+        $allFlagsSet = array_reduce(SuperPowers::getValues(), function ($carry, $value) {
+            return $carry | $value;
+        }, 0);
+        $passed = (new EnumValue(SuperPowers::class))->passes('', $allFlagsSet + 1);
+
+        $this->assertFalse($passed);
     }
 
     public function test_can_turn_off_strict_type_checking()

--- a/tests/EnumValueTest.php
+++ b/tests/EnumValueTest.php
@@ -51,6 +51,16 @@ class EnumValueTest extends TestCase
         $this->assertTrue($passed);
     }
 
+    public function test_flagged_enum_passes_with_all_flags_set()
+    {
+        $allFlags = array_reduce(SuperPowers::getValues(), function (int $carry, int $powerValue) {
+            return $carry | $powerValue;
+        }, 0);
+        $passed = (new EnumValue(SuperPowers::class))->passes('', $allFlags);
+
+        $this->assertTrue($passed);
+    }
+
     public function test_flagged_enum_fails_with_invalid_flag_set()
     {
         $allFlagsSet = array_reduce(SuperPowers::getValues(), function ($carry, $value) {


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Added or updated the [README.md](../README.md)
- [x] Detailed changes in the [CHANGELOG.md](../CHANGELOG.md) unreleased section

This changes the validation for flagged enums. I would consider the current behaviour as undesired. This might impact someones code.