### PR TITLE
set locale for localized description by method parameter

### DIFF
--- a/src/Enum.php
+++ b/src/Enum.php
@@ -252,12 +252,13 @@ abstract class Enum implements EnumContract
      * Get the description for an enum value
      *
      * @param  mixed  $value
+     * @param  string|null $locale
      * @return string
      */
-    public static function getDescription($value): string
+    public static function getDescription($value, ?string $locale = null): string
     {
         return
-            static::getLocalizedDescription($value) ??
+            static::getLocalizedDescription($value, $locale) ??
             static::getFriendlyKeyName(static::getKey($value));
     }
 
@@ -268,15 +269,16 @@ abstract class Enum implements EnumContract
      * for the enum and if the key exists in the lang file.
      *
      * @param  mixed  $value
+     * @param  string|null $locale
      * @return string|null
      */
-    protected static function getLocalizedDescription($value): ?string
+    protected static function getLocalizedDescription($value, ?string $locale = null): ?string
     {
         if (static::isLocalizable()) {
             $localizedStringKey = static::getLocalizationKey() . '.' . $value;
 
-            if (Lang::has($localizedStringKey)) {
-                return __($localizedStringKey);
+            if (Lang::has($localizedStringKey, $locale)) {
+                return __($localizedStringKey, [], $locale);
             }
         }
 

--- a/tests/EnumLocalizationTest.php
+++ b/tests/EnumLocalizationTest.php
@@ -15,6 +15,12 @@ class EnumLocalizationTest extends ApplicationTestCase
         $this->assertEquals('Súper administrador', UserTypeLocalized::getDescription(UserTypeLocalized::SuperAdministrator));
     }
 
+    public function test_enum_get_description_with_localization_locale_in_parameter()
+    {
+        $this->app->setLocale('en');
+        $this->assertEquals('Súper administrador', UserTypeLocalized::getDescription(UserTypeLocalized::SuperAdministrator, 'es'));
+    }
+
     public function test_enum_get_description_for_missing_localization_key()
     {
         $this->app->setLocale('en');


### PR DESCRIPTION
- [x] Added or updated tests

**Related Issue/Intent**

Change used locale for enum transaltions.
It can be used in send emails where email recipient has other locale than user who use application and his locale is in app locale.
Or in api, where application do not have set global locale from user session, but locale is in api request or stored in database for example.

**Changes**

add $locale parameter in to Enum::getDescription method
