### PR TITLE
Add new instantiation methods `Enum::fromKey()` and `Enum::fromValue()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-### Changed
+- Add new instantiation methods `Enum::fromKey()` and `Enum::fromValue()`
+
+### Deprecated
+
+- Deprecate `Enum::getInstance()` in favor of `Enum::fromValue()`
 
 ## [1.37.0](https://github.com/BenSampo/laravel-enum/compare/v1.36.0...v1.37.0) - 2020-04-11
 

--- a/README.md
+++ b/README.md
@@ -123,8 +123,11 @@ For convenience, enums can be instantiated in multiple ways:
 // Standard new PHP class, passing the desired enum value as a parameter
 $enumInstance = new UserType(UserType::Administrator);
 
-// Static getInstance method, again passing the desired enum value as a parameter
-$enumInstance = UserType::getInstance(UserType::Administrator);
+// Same as the constructor, instantiate by value
+$enumInstance = UserType::fromValue(UserType::Administrator);
+
+// Use an enum key instead of its value
+$enumInstance = UserType::fromKey('Administrator');
 
 // Statically calling the key name as a method, utilizing __callStatic magic
 $enumInstance = UserType::Administrator();
@@ -153,7 +156,7 @@ php artisan enum:annotate "App\Enums\UserType"
 Once you have an enum instance, you can access the `key`, `value` and `description` as properties.
 
 ```php
-$userType = UserType::getInstance(UserType::SuperAdministrator);
+$userType = UserType::fromValue(UserType::SuperAdministrator);
 
 $userType->key; // SuperAdministrator
 $userType->value; // 0
@@ -168,7 +171,7 @@ Enum instances can be cast to strings as they implement the `__toString()` magic
 This also means they can be echoed in blade views, for example.
 
 ```php
-$userType = UserType::getInstance(UserType::SuperAdministrator);
+$userType = UserType::fromValue(UserType::SuperAdministrator);
 
 (string) $userType // '0'
 ```
@@ -178,7 +181,7 @@ $userType = UserType::getInstance(UserType::SuperAdministrator);
 You can check the equality of an instance against any value by passing it to the `is` method. For convenience, there is also an `isNot` method which is the exact reverse of the `is` method.
 
 ```php
-$admin = UserType::getInstance(UserType::Administrator);
+$admin = UserType::fromValue(UserType::Administrator);
 
 $admin->is(UserType::Administrator);   // true
 $admin->is($admin);                    // true
@@ -192,7 +195,7 @@ $admin->is('random-value');            // false
 You can also check to see if the instance's value matches against an array of possible values using the `in` method.
 
 ```php
-$admin = UserType::getInstance(UserType::Administrator);
+$admin = UserType::fromValue(UserType::Administrator);
 
 $admin->in([UserType::Moderator, UserType::Administrator]);     // true
 $admin->in([UserType::Moderator(), UserType::Administrator()]); // true
@@ -215,8 +218,8 @@ function canPerformAction(UserType $userType)
     return false;
 }
 
-$userType1 = UserType::getInstance(UserType::SuperAdministrator);
-$userType2 = UserType::getInstance(UserType::Moderator);
+$userType1 = UserType::fromValue(UserType::SuperAdministrator);
+$userType2 = UserType::fromValue(UserType::Moderator);
 
 canPerformAction($userType1); // Returns true
 canPerformAction($userType2); // Returns false
@@ -815,12 +818,12 @@ Returns the enum for use in a select as value => description.
 UserType::toSelectArray(); // Returns [0 => 'Administrator', 1 => 'Moderator', 2 => 'Subscriber', 3 => 'Super administrator']
 ```
 
-### static getInstance(mixed $enumValue): Enum
+### static fromValue(mixed $enumValue): Enum
 
 Returns an instance of the called enum. Read more about [enum instantiation](#instantiation).
 
 ``` php
-UserType::getInstance(UserType::Administrator); // Returns instance of Enum with the value set to UserType::Administrator
+UserType::fromValue(UserType::Administrator); // Returns instance of Enum with the value set to UserType::Administrator
 ```
 
 ### static getInstances(): array

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -84,7 +84,7 @@ abstract class Enum implements EnumContract
      * @param  mixed  $enumValue
      * @return static
      *
-     * @deprecated in favor of fromValue(), will be removed in v2
+     * @deprecated in favor of fromValue(), might be removed in a major version
      */
     public static function getInstance($enumValue): self
     {

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -4,6 +4,7 @@ namespace BenSampo\Enum;
 
 use BenSampo\Enum\Contracts\EnumContract;
 use BenSampo\Enum\Contracts\LocalizedEnum;
+use BenSampo\Enum\Exceptions\InvalidEnumKeyException;
 use BenSampo\Enum\Exceptions\InvalidEnumMemberException;
 use Illuminate\Support\Facades\Lang;
 use Illuminate\Support\Str;
@@ -63,6 +64,50 @@ abstract class Enum implements EnumContract
     }
 
     /**
+     * Make a new instance from an enum value.
+     *
+     * @param  mixed  $enumValue
+     * @return static
+     */
+    public static function fromValue($enumValue): self
+    {
+        if ($enumValue instanceof static) {
+            return $enumValue;
+        }
+
+        return new static($enumValue);
+    }
+
+    /**
+     * Alias for fromValue();
+     *
+     * @param  mixed  $enumValue
+     * @return static
+     *
+     * @deprecated in favor of fromValue(), will be removed in v2
+     */
+    public static function getInstance($enumValue): self
+    {
+        return static::fromValue($enumValue);
+    }
+
+    /**
+     * Make an enum instance from a given key.
+     *
+     * @param  string  $key
+     * @return static
+     */
+    public static function fromKey(string $key): self
+    {
+        if (static::hasKey($key)) {
+            $enumValue = static::getValue($key);
+            return new static($enumValue);
+        }
+
+        throw new InvalidEnumKeyException($key, static::class);
+    }
+
+    /**
      * Attempt to instantiate an enum by calling the enum key as a static method.
      *
      * This function defers to the macroable __callStatic function if a macro is found using the static method called.
@@ -77,12 +122,7 @@ abstract class Enum implements EnumContract
             return static::macroCallStatic($method, $parameters);
         }
 
-        if (static::hasKey($method)) {
-            $enumValue = static::getValue($method);
-            return new static($enumValue);
-        }
-
-        throw new \BadMethodCallException("Cannot create an enum instance for $method. The enum value $method does not exist.");
+        return static::fromKey($method);
     }
 
     /**
@@ -137,21 +177,6 @@ abstract class Enum implements EnumContract
     }
 
     /**
-     * Return a new Enum instance,
-     *
-     * @param  mixed  $enumValue
-     * @return static
-     */
-    public static function getInstance($enumValue): self
-    {
-        if ($enumValue instanceof static) {
-            return $enumValue;
-        }
-
-        return new static($enumValue);
-    }
-
-    /**
      * Return instances of all the contained values.
      *
      * @return static[]
@@ -179,11 +204,12 @@ abstract class Enum implements EnumContract
         }
 
         if (static::hasValue($enumKeyOrValue)) {
-            return static::getInstance($enumKeyOrValue);
+            return static::fromValue($enumKeyOrValue);
         }
 
         if (is_string($enumKeyOrValue) && static::hasKey($enumKeyOrValue)) {
-            return static::$enumKeyOrValue();
+            $enumValue = static::getValue($enumKeyOrValue);
+            return new static($enumValue);
         }
 
         return null;

--- a/src/Exceptions/InvalidEnumKeyException.php
+++ b/src/Exceptions/InvalidEnumKeyException.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace BenSampo\Enum\Exceptions;
+
+use Exception;
+
+class InvalidEnumKeyException extends Exception
+{
+    /**
+     * Create an InvalidEnumKeyException.
+     *
+     * @param  mixed  $invalidKey
+     * @param  string  $enumClass  A class-string of type \Bensampo\Enum\Enum
+     * @return void
+     */
+    public function __construct($invalidKey, string $enumClass)
+    {
+        $invalidValueType = gettype($invalidKey);
+        $enumKeys = implode(', ', $enumClass::getKeys());
+        $enumClassName = class_basename($enumClass);
+
+        parent::__construct("Cannot construct an instance of $enumClassName using the key ($invalidValueType) `$invalidKey`. Possible keys are [$enumKeys].");
+    }
+}

--- a/src/FlaggedEnum.php
+++ b/src/FlaggedEnum.php
@@ -7,7 +7,7 @@ use BenSampo\Enum\Exceptions\InvalidEnumMemberException;
 abstract class FlaggedEnum extends Enum
 {
     const None = 0;
-    
+
     /**
      * Construct a FlaggedEnum instance.
      *
@@ -38,7 +38,7 @@ abstract class FlaggedEnum extends Enum
      */
     public static function flags($flags): self
     {
-        return static::getInstance($flags);
+        return static::fromValue($flags);
     }
 
     /**
@@ -50,7 +50,7 @@ abstract class FlaggedEnum extends Enum
     public function setFlags(array $flags): self
     {
         $this->value = array_reduce($flags, function ($carry, $flag) {
-            return $carry | static::getInstance($flag)->value;
+            return $carry | static::fromValue($flag)->value;
         }, 0);
 
         return $this;
@@ -64,7 +64,7 @@ abstract class FlaggedEnum extends Enum
      */
     public function addFlag($flag): self
     {
-        $this->value |= static::getInstance($flag)->value;
+        $this->value |= static::fromValue($flag)->value;
 
         return $this;
     }
@@ -92,7 +92,7 @@ abstract class FlaggedEnum extends Enum
      */
     public function removeFlag($flag): self
     {
-        $this->value &= ~ static::getInstance($flag)->value;
+        $this->value &= ~ static::fromValue($flag)->value;
 
         return $this;
     }
@@ -120,12 +120,12 @@ abstract class FlaggedEnum extends Enum
      */
     public function hasFlag($flag): bool
     {
-        $flagValue = static::getInstance($flag)->value;
+        $flagValue = static::fromValue($flag)->value;
 
         if ($flagValue === 0) {
             return false;
         }
-        
+
         return ($flagValue & $this->value) === $flagValue;
     }
 

--- a/src/Traits/CastsEnums.php
+++ b/src/Traits/CastsEnums.php
@@ -45,7 +45,7 @@ trait CastsEnums
                     $value = $this->castAttribute($key, $value);
                 }
 
-                $this->attributes[$key] = $enum::getInstance($value)->value;
+                $this->attributes[$key] = $enum::fromValue($value)->value;
             }
 
             return $this;
@@ -86,7 +86,7 @@ trait CastsEnums
         if ($value === null || $value instanceof Enum) {
             return $value;
         } else {
-            return $enum::getInstance($value);
+            return $enum::fromValue($value);
         }
     }
 }

--- a/tests/EnumComparisonTest.php
+++ b/tests/EnumComparisonTest.php
@@ -11,14 +11,14 @@ class EnumComparisonTest extends TestCase
 {
     public function test_comparison_against_plain_value_matching()
     {
-        $admin = UserType::getInstance(UserType::Administrator);
+        $admin = UserType::fromValue(UserType::Administrator);
 
         $this->assertTrue($admin->is(UserType::Administrator));
     }
 
     public function test_comparison_against_plain_value_not_matching()
     {
-        $admin = UserType::getInstance(UserType::Administrator);
+        $admin = UserType::fromValue(UserType::Administrator);
 
         $this->assertFalse($admin->is(UserType::SuperAdministrator));
         $this->assertFalse($admin->is('some-random-value'));
@@ -28,23 +28,23 @@ class EnumComparisonTest extends TestCase
 
     public function test_comparison_against_itself_matches()
     {
-        $admin = UserType::getInstance(UserType::Administrator);
+        $admin = UserType::fromValue(UserType::Administrator);
 
         $this->assertTrue($admin->is($admin));
     }
 
     public function test_comparison_against_other_instances_matches()
     {
-        $admin = UserType::getInstance(UserType::Administrator);
-        $anotherAdmin = UserType::getInstance(UserType::Administrator);
+        $admin = UserType::fromValue(UserType::Administrator);
+        $anotherAdmin = UserType::fromValue(UserType::Administrator);
 
         $this->assertTrue($admin->is($anotherAdmin));
     }
 
     public function test_comparison_against_other_instances_not_matching()
     {
-        $admin = UserType::getInstance(UserType::Administrator);
-        $superAdmin = UserType::getInstance(UserType::SuperAdministrator);
+        $admin = UserType::fromValue(UserType::Administrator);
+        $superAdmin = UserType::fromValue(UserType::SuperAdministrator);
 
         $this->assertFalse($admin->is($superAdmin));
     }
@@ -68,7 +68,7 @@ class EnumComparisonTest extends TestCase
     /**
      * @test
      * Verify that relational comparision of Enum object uses attribute `$value`
-     * 
+     *
      * "comparison operation stops and returns at the first unequal property found."
      * as stated in https://www.php.net/manual/en/language.oop5.object-comparison.php#98725
      * @return void

--- a/tests/EnumInstanceTest.php
+++ b/tests/EnumInstanceTest.php
@@ -2,46 +2,62 @@
 
 namespace BenSampo\Enum\Tests;
 
+use BenSampo\Enum\Exceptions\InvalidEnumKeyException;
 use PHPUnit\Framework\TestCase;
 use BenSampo\Enum\Tests\Enums\UserType;
-use BenSampo\Enum\Tests\Enums\StringValues;
 use BenSampo\Enum\Exceptions\InvalidEnumMemberException;
 
 class EnumInstanceTest extends TestCase
 {
-    public function test_can_instantiate_enum_class()
+    public function test_can_instantiate_enum_class_with_new()
     {
-        $userType = UserType::getInstance(UserType::Administrator);
+        $userType = new UserType(UserType::Administrator);
         $this->assertInstanceOf(UserType::class, $userType);
+    }
 
-        $stringValues = new StringValues(StringValues::Moderator);
-        $this->assertInstanceOf(StringValues::class, $stringValues);
+    public function test_can_instantiate_enum_class_from_value()
+    {
+        $userType = UserType::fromValue(UserType::Administrator);
+        $this->assertInstanceOf(UserType::class, $userType);
+    }
+
+    public function test_can_instantiate_enum_class_from_key()
+    {
+        $userType = UserType::fromKey('Administrator');
+        $this->assertInstanceOf(UserType::class, $userType);
     }
 
     public function test_an_exception_is_thrown_when_trying_to_instantiate_enum_class_with_an_invalid_enum_value()
     {
         $this->expectException(InvalidEnumMemberException::class);
 
-        UserType::getInstance('InvalidValue');
+        UserType::fromValue('InvalidValue');
+    }
+
+    public function test_an_exception_is_thrown_when_trying_to_instantiate_enum_class_with_an_invalid_enum_key()
+    {
+        $this->expectException(InvalidEnumKeyException::class);
+
+        UserType::fromKey('foobar');
     }
 
     public function test_can_get_the_value_for_an_enum_instance()
     {
-        $userType = UserType::getInstance(UserType::Administrator);
+        $userType = UserType::fromValue(UserType::Administrator);
 
         $this->assertEquals($userType->value, UserType::Administrator);
     }
 
     public function test_can_get_the_key_for_an_enum_instance()
     {
-        $userType = UserType::getInstance(UserType::Administrator);
+        $userType = UserType::fromValue(UserType::Administrator);
 
         $this->assertEquals($userType->key, UserType::getKey(UserType::Administrator));
     }
 
     public function test_can_get_the_description_for_an_enum_instance()
     {
-        $userType = UserType::getInstance(UserType::Administrator);
+        $userType = UserType::fromValue(UserType::Administrator);
 
         $this->assertEquals($userType->description, UserType::getDescription(UserType::Administrator));
     }
@@ -53,13 +69,13 @@ class EnumInstanceTest extends TestCase
 
     public function test_an_exception_is_thrown_when_trying_to_get_enum_instance_by_calling_an_enum_key_as_a_static_method_which_does_not_exist()
     {
-        $this->expectException(\BadMethodCallException::class);
+        $this->expectException(InvalidEnumKeyException::class);
 
         UserType::KeyWhichDoesNotExist();
     }
 
     public function test_getting_an_instance_using_an_instance_returns_an_instance()
     {
-        $this->assertInstanceOf(UserType::class, UserType::getInstance(UserType::Administrator));
+        $this->assertInstanceOf(UserType::class, UserType::fromValue(UserType::Administrator));
     }
 }

--- a/tests/EnumTypeHintTest.php
+++ b/tests/EnumTypeHintTest.php
@@ -9,8 +9,8 @@ class EnumTypeHintTest extends TestCase
 {
     public function test_can_pass_an_enum_instance_to_a_type_hinted_method()
     {
-        $userType1 = UserType::getInstance(UserType::SuperAdministrator);
-        $userType2 = UserType::getInstance(UserType::Moderator);
+        $userType1 = UserType::fromValue(UserType::SuperAdministrator);
+        $userType2 = UserType::fromValue(UserType::Moderator);
 
         $this->assertTrue($this->typeHintedMethod($userType1));
         $this->assertFalse($this->typeHintedMethod($userType2));

--- a/tests/FlaggedEnumTest.php
+++ b/tests/FlaggedEnumTest.php
@@ -13,7 +13,7 @@ class FlaggedEnumTest extends TestCase
         $powers = new SuperPowers([SuperPowers::Strength, SuperPowers::Flight, SuperPowers::LaserVision]);
         $this->assertInstanceOf(SuperPowers::class, $powers);
 
-        $powers = SuperPowers::getInstance([SuperPowers::Strength, SuperPowers::Flight, SuperPowers::LaserVision]);
+        $powers = SuperPowers::fromValue([SuperPowers::Strength, SuperPowers::Flight, SuperPowers::LaserVision]);
         $this->assertInstanceOf(SuperPowers::class, $powers);
 
         $powers = SuperPowers::flags([SuperPowers::Strength, SuperPowers::Flight, SuperPowers::LaserVision]);
@@ -26,7 +26,7 @@ class FlaggedEnumTest extends TestCase
         $powers = new SuperPowers([SuperPowers::Strength(), SuperPowers::Flight(), SuperPowers::LaserVision()]);
         $this->assertInstanceOf(SuperPowers::class, $powers);
 
-        $powers = SuperPowers::getInstance([SuperPowers::Strength(), SuperPowers::Flight(), SuperPowers::LaserVision()]);
+        $powers = SuperPowers::fromValue([SuperPowers::Strength(), SuperPowers::Flight(), SuperPowers::LaserVision()]);
         $this->assertInstanceOf(SuperPowers::class, $powers);
 
         $powers = SuperPowers::flags([SuperPowers::Strength(), SuperPowers::Flight(), SuperPowers::LaserVision()]);
@@ -79,7 +79,7 @@ class FlaggedEnumTest extends TestCase
         /** @var SuperPowers $powers */
         $powers = SuperPowers::None();
         $this->assertFalse($powers->hasFlag(SuperPowers::LaserVision));
-        
+
         $powers->setFlags([SuperPowers::LaserVision, SuperPowers::Strength]);
         $this->assertTrue($powers->hasFlag(SuperPowers::LaserVision));
         $this->assertTrue($powers->hasFlag(SuperPowers::Strength));
@@ -90,7 +90,7 @@ class FlaggedEnumTest extends TestCase
         /** @var SuperPowers $powers */
         $powers = SuperPowers::None();
         $this->assertFalse($powers->hasFlag(SuperPowers::LaserVision));
-        
+
         $powers->addFlag(SuperPowers::LaserVision);
         $this->assertTrue($powers->hasFlag(SuperPowers::LaserVision));
 
@@ -103,7 +103,7 @@ class FlaggedEnumTest extends TestCase
         /** @var SuperPowers $powers */
         $powers = SuperPowers::None();
         $this->assertFalse($powers->hasFlag(SuperPowers::LaserVision));
-        
+
         $powers->addFlags([SuperPowers::LaserVision, SuperPowers::Strength]);
         $this->assertTrue($powers->hasFlags([SuperPowers::LaserVision, SuperPowers::Strength]));
     }
@@ -113,7 +113,7 @@ class FlaggedEnumTest extends TestCase
         /** @var SuperPowers $powers */
         $powers = new SuperPowers([SuperPowers::Strength, SuperPowers::Flight]);
         $this->assertTrue($powers->hasFlags([SuperPowers::Strength, SuperPowers::Flight]));
-        
+
         $powers->removeFlag(SuperPowers::Strength);
         $this->assertFalse($powers->hasFlag(SuperPowers::Strength));
 
@@ -128,7 +128,7 @@ class FlaggedEnumTest extends TestCase
         /** @var SuperPowers $powers */
         $powers = new SuperPowers([SuperPowers::Strength, SuperPowers::Flight]);
         $this->assertTrue($powers->hasFlags([SuperPowers::Strength, SuperPowers::Flight]));
-        
+
         $powers->removeFlags([SuperPowers::Strength, SuperPowers::Flight]);
         $this->assertFalse($powers->hasFlags([SuperPowers::Strength, SuperPowers::Flight]));
 
@@ -160,7 +160,7 @@ class FlaggedEnumTest extends TestCase
         /** @var SuperPowers $powers */
         $powers = new SuperPowers([SuperPowers::Strength, SuperPowers::LaserVision, SuperPowers::Flight]);
         $this->assertTrue($powers->hasFlag(SuperPowers::Superman));
-        
+
         $powers->removeFlag([SuperPowers::LaserVision]);
         $this->assertFalse($powers->hasFlag(SuperPowers::Superman));
     }
@@ -184,6 +184,6 @@ class FlaggedEnumTest extends TestCase
     {
         $powers = new SuperPowers([SuperPowers::Strength, SuperPowers::Flight]);
 
-        $this->assertEquals($powers, SuperPowers::getInstance($powers->value));
+        $this->assertEquals($powers, SuperPowers::fromValue($powers->value));
     }
 }


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Added or updated the [README.md](../README.md)
- [x] Detailed changes in the [CHANGELOG.md](../CHANGELOG.md) unreleased section

**Related Issue/Intent**

This use case has come up for us because we use Enum's in two ways:
- values are used for efficient storage in the database
- keys are used for a nice client API

**Changes**

Add new instantiation methods `Enum::fromKey()` and `Enum::fromValue()`

Deprecate `Enum::getInstance()` in favor of `Enum::fromValue()`, as the
new name is consistent with `Enum::fromKey()`

**Breaking changes**

None, but i propose to remove `getInstance()` in an upcoming major version.