### PR TITLE
Add RFC 5424 log level enum library

### DIFF
--- a/enum-library.md
+++ b/enum-library.md
@@ -8,3 +8,4 @@ If you wish to contribute an enum, please submit via a pull request.
 - [Days of the week](https://gist.github.com/BenSampo/84ffa24efe2b1bc719aba8d1e666b7c3) - submitted by [Ben Sampson](https://github.com/bensampo)
 - [Months of the year](https://gist.github.com/BenSampo/46e620affe0e97e489e35e8bce914920) - submitted by [Ben Sampson](https://github.com/bensampo)
 - [Country calling codes](https://gist.github.com/MammutAlex/af182c622fc10991ce42f2397fb54e4a) - submitted by [Alex Kovalchuk](https://github.com/MammutAlex)
+- [RFC 5424 log levels](https://gist.github.com/othyn/fd2fb2e611de832398e42130f2f2143d) - submitted by [Ben Tindall](https://github.com/othyn), [RFC spec](https://tools.ietf.org/html/rfc5424).


### PR DESCRIPTION
- [ ] Added or updated tests - _N/A_
- [ ] Added or updated the [README.md](../README.md) - _N/A_
- [ ] Detailed changes in the [CHANGELOG.md](../CHANGELOG.md) unreleased section - _Release is out of my control_

**Related Issue/Intent**

<!-- Link to related issues this PR resolves, e.g. "Resolves #236",
or a description of what this PR is trying to achieve. -->

A very simple addition that adds an enum library for RFC 5424 log levels.

**Changes**

<!-- Detail the changes in behaviour this PR introduces. -->

Edit of the  `./enum-library.md` to include a reference to a new enum library for RFC 5424 log levels.

**Breaking changes**

<!-- If there are any breaking changes, list them here. -->
