### PR TITLE
Handle calling magic instantiation methods from within instance methods of the Enum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/BenSampo/laravel-enum/compare/v1.37.0...master)
 
-### Added
+### Fixed
 
-### Changed
+- Handle calling magic instantiation methods from within instance methods of the Enum
 
 ## [1.37.0](https://github.com/BenSampo/laravel-enum/compare/v1.36.0...v1.37.0) - 2020-04-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Handle calling magic instantiation methods from within instance methods of the Enum
+- Handle calling magic instantiation methods from within instance methods of the Enum [#147](https://github.com/BenSampo/laravel-enum/pull/147)
 
 ## [1.37.0](https://github.com/BenSampo/laravel-enum/compare/v1.36.0...v1.37.0) - 2020-04-11
 

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -13,8 +13,8 @@ use ReflectionClass;
 abstract class Enum implements EnumContract
 {
     use Macroable {
-        // Because this class also defines a '__callStatic' method, a new name has to be given to the trait's '__callStatic' method.
         __callStatic as macroCallStatic;
+        __call as macroCall;
     }
 
     /**
@@ -83,6 +83,27 @@ abstract class Enum implements EnumContract
         }
 
         throw new \BadMethodCallException("Cannot create an enum instance for $method. The enum value $method does not exist.");
+    }
+
+    /**
+     * Delegate magic method calls to macro's or the static call.
+     *
+     * While it is not typical to use the magic instantiation dynamically, it may happen
+     * incidentally when calling the instantiation in an instance method of itself.
+     * Even when using the `static::KEY()` syntax, PHP still interprets this is a call to
+     * an instance method when it happens inside of an instance method of the same class.
+     *
+     * @param  string  $method
+     * @param  mixed  $parameters
+     * @return mixed
+     */
+    public function __call($method, $parameters)
+    {
+        if (static::hasMacro($method)) {
+            return $this->macroCall($method, $parameters);
+        }
+
+        return self::__callStatic($method, $parameters);
     }
 
     /**

--- a/tests/EnumInstanceTest.php
+++ b/tests/EnumInstanceTest.php
@@ -51,6 +51,12 @@ class EnumInstanceTest extends TestCase
         $this->assertInstanceOf(UserType::class, UserType::Administrator());
     }
 
+    public function test_magic_instantiation_from_instance_method()
+    {
+        $userType = new UserType(UserType::Administrator);
+        $this->assertInstanceOf(UserType::class, $userType->magicInstantiationFromInstanceMethod());
+    }
+
     public function test_an_exception_is_thrown_when_trying_to_get_enum_instance_by_calling_an_enum_key_as_a_static_method_which_does_not_exist()
     {
         $this->expectException(\BadMethodCallException::class);

--- a/tests/EnumTest.php
+++ b/tests/EnumTest.php
@@ -125,7 +125,7 @@ class EnumTest extends TestCase
         $this->assertEquals($expectedArray, $array);
     }
 
-    public function test_enum_is_macroable()
+    public function test_enum_is_macroable_with_static_methods()
     {
         Enum::macro('toFlippedArray', function () {
             return array_flip(self::toArray());
@@ -133,6 +133,18 @@ class EnumTest extends TestCase
 
         $this->assertTrue(UserType::hasMacro('toFlippedArray'));
         $this->assertEquals(UserType::toFlippedArray(), array_flip(UserType::toArray()));
+    }
+
+    public function test_enum_is_macroable_with_instance_methods()
+    {
+        Enum::macro('macroGetValue', function () {
+            return $this->value;
+        });
+
+        $this->assertTrue(UserType::hasMacro('macroGetValue'));
+
+        $user = new UserType(UserType::Administrator);
+        $this->assertSame(UserType::Administrator, $user->macroGetValue());
     }
 
     public function test_enum_get_instances()

--- a/tests/Enums/UserType.php
+++ b/tests/Enums/UserType.php
@@ -10,4 +10,9 @@ final class UserType extends Enum
     const Moderator = 1;
     const Subscriber = 2;
     const SuperAdministrator = 3;
+
+    public function magicInstantiationFromInstanceMethod(): self
+    {
+        return self::Administrator();
+    }
 }


### PR DESCRIPTION
- [x] Added or updated tests
- ~[ ] Added or updated the [README.md](../README.md)~
- [x] Detailed changes in the [CHANGELOG.md](../CHANGELOG.md) unreleased section

**Related Issue/Intent**

Here is a actual code we use that did not work as expected:

```php
use BenSampo\Enum\Enum;

/**
 * @method static Workgroup ROUTINE()
 * @method static Workgroup MLL5K()
 * @method static Workgroup MLL5Kv2()
 */
final class Workgroup extends Enum
{
    protected const ROUTINE = 'Routine';
    protected const MLL5K = 'MLL5K';
    protected const MLL5Kv2 = 'MLL5Kv2';

    /**
     * @return array<self>
     */
    public function allPrioritized(): array
    {
        switch ($this->value) {
            case self::MLL5K:
                return [
                    self::MLL5K(),
                    self::ROUTINE(),
                    self::MLL5Kv2(),
                ];
            case self::MLL5Kv2:
                return [
                    self::MLL5Kv2(),
                    self::ROUTINE(),
                    self::MLL5K(),
                ];
            default:
                return [
                    self::ROUTINE(),
                    self::MLL5K(),
                    self::MLL5Kv2(),
                ];
        }
    }
}
```

Calling `$workgroup->allPrioritized()` fails with an error message like this:

```
BadMethodCallException: Method App\Enums\Workgroup::ROUTINE does not exist.
```

Even though the call to `self::ROUTINE()` looks like a static method call, PHP actually treats it as dynamic and calls `__call` rather than `__callStatic`.

**Changes**

Allow such magic instantiation calls from within an enum.

While it is not typical to use the magic instantiation dynamically, it may happen
incidentally when calling the instantiation in an instance method of itself.
Even when using the `static::KEY()` syntax, PHP still interprets this is a call to
an instance method when it happens inside of an instance method of the same class.

**Breaking changes**

None, i took particular care to ensure that dynamic macro's stil work.
