### PR TITLE
Allow to return null on native cast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/BenSampo/laravel-enum/compare/v1.38.0...master)
 
+### Fixed
+
+- Allow to return `null` when using native casting
+
 ## [2.0.0](https://github.com/BenSampo/laravel-enum/compare/v1.38.0...v2.0.0) - 2020-07-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -460,6 +460,26 @@ final class UserType extends Enum
 }
 ```
 
+Many databases have inconsistent data for blank values using both `NULL` or an empty string to store them.
+You can use this method to check for blank values and return `null` to avoid casting to an enum instance:
+
+```php
+final class UserType extends Enum
+{
+    const Administrator = 0;
+    const Moderator = 1;
+    
+    public static function parseDatabase($value)
+    {
+        if (! $value) {
+            return null;
+        }
+
+        return (int) $value;
+    }
+}
+```
+
 ### Model Annotation
 
 The package can automatically generate DocBlocks for your `Model` classes to provide type hinting & completion in your IDE.

--- a/src/Casts/EnumCast.php
+++ b/src/Casts/EnumCast.php
@@ -47,6 +47,10 @@ class EnumCast implements CastsAttributes
 
         $value = $this->getCastableValue($value);
 
+        if ($value === null) {
+            return null;
+        }
+
         return $this->enumClass::getInstance($value);
     }
 
@@ -59,8 +63,12 @@ class EnumCast implements CastsAttributes
      */
     protected function getCastableValue($value)
     {
-        // If the enum has overridden the `castNative` method, use it to get the cast value
+        // If the enum has overridden the `parseDatabase` method, use it to get the cast value
         $value = $this->enumClass::parseDatabase($value);
+
+        if ($value === null) {
+            return null;
+        }
 
         // If the value exists in the enum (using strict type checking) return it
         if ($this->enumClass::hasValue($value)) {

--- a/tests/Enums/UserTypeCustomCast.php
+++ b/tests/Enums/UserTypeCustomCast.php
@@ -13,11 +13,19 @@ final class UserTypeCustomCast extends Enum
 
     public static function parseDatabase($value)
     {
+        if (! $value) {
+            return null;
+        }
+
         return explode('-', $value)[1] ?? null;
     }
 
     public static function serializeDatabase($value)
     {
+        if (! $value) {
+            return null;
+        }
+
         return 'type-' . $value;
     }
 }

--- a/tests/NativeEnumCastTest.php
+++ b/tests/NativeEnumCastTest.php
@@ -92,4 +92,16 @@ class NativeEnumCastTest extends TestCase
 
         $this->assertSame('type-0', $reflection->getValue($model)['user_type_custom']);
     }
+
+    public function test_can_bail_custom_casting()
+    {
+        /** @var NativeCastModel $model */
+        $model = app(NativeCastModel::class);
+
+        $reflection = new \ReflectionProperty(NativeCastModel::class, 'attributes');
+        $reflection->setAccessible(true);
+        $reflection->setValue($model, ['user_type_custom' => '']);
+
+        $this->assertNull($model->user_type_custom);
+    }
 }


### PR DESCRIPTION
- [x] Added or updated tests
- [X] Added or updated the [README.md](../README.md)
- [X] Detailed changes in the [CHANGELOG.md](../CHANGELOG.md) unreleased section

**Related Issue/Intent**

<!-- Link to related issues this PR resolves, e.g. "Resolves #236",
or a description of what this PR is trying to achieve. -->

When using the native casting introduced in v2.0 I noticed that returning `null` from the `parseDatabase` method would result in error as it would still try to create an Enum instance from the returned value.

My use case is a modernization of a legacy codebase (25 years old) where some blank data is stored as empty strings instead of `NULL`s in the database.

So when running code like this:

~~~php
public static function parseDatabase($value)
{
    if (\blank($value)) {
        return null;
    }

     return (int) $value;
}
~~~

Application would throw an exception on blank values (`null` or empty string).

For this particular project I ended adding a `NA` enum value and defaulting to that for blank values. This is not an ideal solution as the code that relies on the Enum value, and code to persist values back needs to take account of that.

**Changes**

<!-- Detail the changes in behaviour this PR introduces. -->

This PR changes the `Casts/EnumCast` class to check for `null` values returned by userland code when using the `parseDatabase` method.

A new test was added. Test would fail without the changes introduced by this PR.

**Breaking changes**

<!-- If there are any breaking changes, list them here. -->

No breaking changes.
