### PR TITLE
Implement flipped select array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/BenSampo/laravel-enum/compare/v1.38.0...master)
 
+### Added
+
+- Implement flipped select array, to allow for the format "description => value"
+
 ## [2.0.0](https://github.com/BenSampo/laravel-enum/compare/v1.38.0...v2.0.0) - 2020-07-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -826,6 +826,14 @@ Returns the enum for use in a select as value => description.
 UserType::toSelectArray(); // Returns [0 => 'Administrator', 1 => 'Moderator', 2 => 'Subscriber', 3 => 'Super administrator']
 ```
 
+### static toFlippedSelectArray(): array
+
+Returns the enum for use in a select as description => value.
+
+```php
+UserType::toFlippedSelectArray(); // Returns ['Administrator' => 0, 'Moderator' => 1, 'Subscriber' => 2, 'Super administrator' => 3]
+```
+
 ### static fromValue(mixed $enumValue): Enum
 
 Returns an instance of the called enum. Read more about [enum instantiation](#instantiation).

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -399,6 +399,18 @@ abstract class Enum implements EnumContract, Castable
     }
 
     /**
+     * Get the enum as an flipped array formatted for a select.
+     *
+     * [string description => mixed $value]
+     *
+     * @return array
+     */
+    public static function toFlippedSelectArray(): array
+    {
+        return array_flip(static::toSelectArray());
+    }
+
+    /**
      * Check that the enum contains a specific key.
      *
      * @param  string  $key

--- a/tests/EnumTest.php
+++ b/tests/EnumTest.php
@@ -101,6 +101,30 @@ class EnumTest extends TestCase
         $this->assertEquals($expectedArray, $array);
     }
 
+    public function test_enum_to_flipped_select_array()
+    {
+        $array = UserType::toFlippedSelectArray();
+        $expectedArray = [
+            'Administrator' => 0,
+            'Moderator' => 1,
+            'Subscriber' => 2,
+            'Super administrator' => 3,
+        ];
+
+        $this->assertEquals($expectedArray, $array);
+    }
+
+    public function test_enum_to_flipped_select_array_with_string_values()
+    {
+        $array = StringValues::toFlippedSelectArray();
+        $expectedArray = [
+            'Administrator' => 'administrator',
+            'Moderator' => 'moderator',
+        ];
+
+        $this->assertEquals($expectedArray, $array);
+    }
+
     public function test_enum_to_select_array()
     {
         $array = UserType::toSelectArray();


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Added or updated the [README.md](../README.md)
- [x] Detailed changes in the [CHANGELOG.md](../CHANGELOG.md) unreleased section

**Related Issue/Intent**

I ran in to the issue where Laravel Nova needs the "options array" for [a select filter](https://nova.laravel.com/docs/3.0/filters/defining-filters.html#select-filters) to be flipped in respect to the return value of `toSelectArray()`. Currently I simply apply `array_flip` to the array of `toSelectArray()` in my project, but wouldn't it be nice if it's added to the package? 🙂 

**Changes**

I've added a function to `Enum.php` that uses the `toSelectArray()` method and apply `array_flip` before returning the result. I could have added it as an option to `toSelectArray()` (eg. `toSelectArray($flipArray = false)`), but that did not feel right. What do you think? 🤔 

**Breaking changes**

None, hopefully!
