### PR TITLE
Add nullable enum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/BenSampo/laravel-enum/compare/v1.38.0...master)
 
+### Added
+
+- Add NullableEnum Interface.
+
 ## [2.2.0](https://github.com/BenSampo/laravel-enum/compare/v2.1.0...v2.2.0) - 2020-08-30
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -461,6 +461,32 @@ final class UserType extends Enum
 
 Returning `null` from the `parseDatabase` method will cause the attribute on the model to also be `null`. This can be useful if your database stores inconsistent blank values such as empty strings instead of `NULL`.
 
+### Nullable Enum
+By adding `NullableEnum` interface, null values can be instantiated as an enum.
+
+```php
+final class UserType extends Enum implements NullableEnum
+{
+    const Administrator = 0;
+    const Moderator = 1;
+}
+```
+This guarantees that there is always an instance for operations like `is` or `in`.
+```php
+$example = Example::first();
+
+// Set enum value to null
+$example->user_type = null;
+
+// Without NullableEnum this will throw an error.
+$isModerator = $example->user_type->is(UserType::Moderator());
+```
+
+With this interface null enums can be directly created as well.
+```php
+$nullUserType = new UserType(null);
+```
+
 ### Model Annotation
 
 The package can automatically generate DocBlocks for your `Model` classes to provide type hinting & completion in your IDE.

--- a/src/Casts/EnumCast.php
+++ b/src/Casts/EnumCast.php
@@ -41,7 +41,11 @@ class EnumCast implements CastsAttributes
      */
     protected function castEnum($value): ?Enum
     {
-        if ($value === null || $value instanceof $this->enumClass) {
+        if (is_null($value) && $this->enumClass::isNullable()) {
+            return new $this->enumClass($value);
+        }
+
+        if ($value instanceof $this->enumClass) {
             return $value;
         }
 

--- a/src/Contracts/NullableEnum.php
+++ b/src/Contracts/NullableEnum.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace BenSampo\Enum\Contracts;
+
+interface NullableEnum
+{
+    /**
+     * Check the enum implements the NullableEnum interface.
+     *
+     * @return bool
+     */
+    public static function isNullable(): bool;
+}

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -2,19 +2,20 @@
 
 namespace BenSampo\Enum;
 
-use ReflectionClass;
-use JsonSerializable;
-use Illuminate\Support\Str;
 use BenSampo\Enum\Casts\EnumCast;
-use Illuminate\Support\Facades\Lang;
-use Illuminate\Support\Traits\Macroable;
 use BenSampo\Enum\Contracts\EnumContract;
 use BenSampo\Enum\Contracts\LocalizedEnum;
-use Illuminate\Contracts\Support\Arrayable;
-use Illuminate\Contracts\Database\Eloquent\Castable;
+use BenSampo\Enum\Contracts\NullableEnum;
 use BenSampo\Enum\Exceptions\InvalidEnumKeyException;
 use BenSampo\Enum\Exceptions\InvalidEnumMemberException;
+use Illuminate\Contracts\Database\Eloquent\Castable;
 use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Support\Facades\Lang;
+use Illuminate\Support\Str;
+use Illuminate\Support\Traits\Macroable;
+use JsonSerializable;
+use ReflectionClass;
 
 abstract class Enum implements EnumContract, Castable, Arrayable, JsonSerializable
 {
@@ -59,7 +60,7 @@ abstract class Enum implements EnumContract, Castable, Arrayable, JsonSerializab
      */
     public function __construct($enumValue)
     {
-        if (!static::hasValue($enumValue)) {
+        if (!(is_null($enumValue) && static::isNullable()) && !static::hasValue($enumValue)) {
             throw new InvalidEnumMemberException($enumValue, $this);
         }
 
@@ -454,6 +455,16 @@ abstract class Enum implements EnumContract, Castable, Arrayable, JsonSerializab
     public static function getLocalizationKey(): string
     {
         return 'enums.' . static::class;
+    }
+
+    /**
+     * Check the enum implements the NullableEnum interface.
+     *
+     * @return bool
+     */
+    public static function isNullable(): bool
+    {
+        return isset(class_implements(static::class)[NullableEnum::class]);
     }
 
     /**

--- a/tests/Enums/UserTypeNullable.php
+++ b/tests/Enums/UserTypeNullable.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace BenSampo\Enum\Tests\Enums;
+
+use BenSampo\Enum\Contracts\NullableEnum;
+use BenSampo\Enum\Enum;
+
+final class UserTypeNullable extends Enum implements NullableEnum
+{
+    const Moderator = 0;
+    const Administrator = 1;
+    const SuperAdministrator = 2;
+}

--- a/tests/Models/NativeCastModel.php
+++ b/tests/Models/NativeCastModel.php
@@ -4,6 +4,7 @@ namespace BenSampo\Enum\Tests\Models;
 
 use BenSampo\Enum\Tests\Enums\UserType;
 use BenSampo\Enum\Tests\Enums\UserTypeCustomCast;
+use BenSampo\Enum\Tests\Enums\UserTypeNullable;
 use Illuminate\Database\Eloquent\Model;
 
 class NativeCastModel extends Model
@@ -11,10 +12,12 @@ class NativeCastModel extends Model
     protected $casts = [
         'user_type' => UserType::class,
         'user_type_custom' => UserTypeCustomCast::class,
+        'user_type_nullable' => UserTypeNullable::class,
     ];
 
     protected $fillable = [
         'user_type',
         'user_type_custom',
+        'user_type_nullable'
     ];
 }

--- a/tests/NullableEnumTest.php
+++ b/tests/NullableEnumTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace BenSampo\Enum\Tests;
+
+use BenSampo\Enum\Exceptions\InvalidEnumMemberException;
+use BenSampo\Enum\Tests\Enums\UserTypeNullable;
+use BenSampo\Enum\Tests\Models\NativeCastModel;
+
+class NullableEnumTest extends ApplicationTestCase
+{
+    public function test_can_get_and_set_null_on_enum_castable()
+    {
+        $model = app(NativeCastModel::class);
+        $model->user_type_nullable = null;
+
+        $this->assertInstanceOf(UserTypeNullable::class, $model->user_type_nullable);
+    }
+
+    public function test_can_handle_null_from_database()
+    {
+        /** @var NativeCastModel $model */
+        $model = app(NativeCastModel::class);
+
+        $reflection = new \ReflectionProperty(NativeCastModel::class, 'attributes');
+        $reflection->setAccessible(true);
+        $reflection->setValue($model, ['user_type_nullable' => null]);
+
+        $this->assertInstanceOf(UserTypeNullable::class, $model->user_type_nullable);
+    }
+
+    public function test_cannot_set_model_value_using_invalid_enum_value()
+    {
+        $this->expectException(InvalidEnumMemberException::class);
+
+        /** @var NativeCastModel $model */
+        $model = app(NativeCastModel::class);
+
+        $reflection = new \ReflectionProperty(NativeCastModel::class, 'attributes');
+        $reflection->setAccessible(true);
+        $reflection->setValue($model, ['user_type_nullable' => '61']);
+
+        $this->assertInstanceOf(UserTypeNullable::class, $model->user_type_nullable);
+    }
+
+    public function test_null_value_enum_is_instance_of_enum_value()
+    {
+        $this->assertInstanceOf(UserTypeNullable::class, new UserTypeNullable(null));
+    }
+}


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Added or updated the [README.md](../README.md)
- [x] Detailed changes in the [CHANGELOG.md](../CHANGELOG.md) unreleased section

**Related Issue/Intent**
Resolves https://github.com/BenSampo/laravel-enum/issues/171

**Changes**
With this PR, users will be able to create enum instances from null values, both from database and manually. This will eliminate unwanted `PHP Error:  Call to a member function ... on null` error.

**Breaking changes**
No breaking changes as it is optional.
