### PR TITLE
fix:`toSelectArray` breaking change + document `toArray` change

### DIFF
--- a/README.md
+++ b/README.md
@@ -446,6 +446,49 @@ $example->user_type = UserType::Moderator;
 $example->user_type = UserType::Moderator();
 ```
 
+### Customising `$model->toArray()` behaviour
+
+When using `toArray` (or returning model/models from your controller as a response) Laravel will call the `toArray` method on the enum instance. 
+
+By default, this will return only the value in its native type. You may want to also have access to the other properties (key, description), for example to return
+to javascript app. 
+
+To customise this behaviour, you can override the `toArray` method on the enum instance.
+
+```php
+// Example Enum
+final class UserType extends Enum
+{
+    const Administrator = 0;
+    const Moderator = 1;
+}
+
+$instance = UserType::Moderator();
+
+// Default
+public function toArray()
+{
+    return $this->value;
+}
+// Returns int(1)
+
+// Return all properties
+public function toArray()
+{
+    return $this;
+}
+// Returnns an array of all the properties
+// array(3) {
+//  ["value"]=>
+//  string(5) "owner"
+//  ["key"]=>
+//  string(5) "OWNER"
+//  ["description"]=>
+//  string(5) "Owner"
+// }
+
+```
+
 ### Casting underlying native types
 Many databases return everything as strings (for example, an integer may be returned as the string `'1'`).
 To reduce friction for users of the library, we use type coercion to figure out the intended value. If you'd prefer to control this, you can override the `parseDatabase` static method on your enum class:

--- a/README.md
+++ b/README.md
@@ -459,8 +459,8 @@ To customise this behaviour, you can override the `toArray` method on the enum i
 // Example Enum
 final class UserType extends Enum
 {
-    const Administrator = 0;
-    const Moderator = 1;
+    const ADMINISTRATOR = 0;
+    const MODERATOR = 1;
 }
 
 $instance = UserType::Moderator();
@@ -477,14 +477,14 @@ public function toArray()
 {
     return $this;
 }
-// Returnns an array of all the properties
+// Returns an array of all the properties
 // array(3) {
 //  ["value"]=>
-//  string(5) "owner"
+//  int(1)"
 //  ["key"]=>
-//  string(5) "OWNER"
+//  string(9) "MODERATOR"
 //  ["description"]=>
-//  string(5) "Owner"
+//  string(9) "Moderator"
 // }
 
 ```

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -397,6 +397,16 @@ abstract class Enum implements EnumContract, Castable, Arrayable, JsonSerializab
     }
 
     /**
+     * @deprecated use self::asSelectArray()
+     *
+     * @return array
+     */
+    public static function toSelectArray(): array
+    {
+       return self::asSelectArray();
+    }
+
+    /**
      * Check that the enum contains a specific key.
      *
      * @param  string  $key


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Added or updated the [README.md](../README.md)
- [ ] Detailed changes in the [CHANGELOG.md](../CHANGELOG.md) unreleased section

**Related Issue/Intent**

This PR is kind of a combination of a few issues. Mainly, it fixes the breaking change that was renaming `toSelectArray()` on a minor version.

This broke a few of my apps, and broke another client's app today.

There was also another breaking change (switching the behaviour of `toArray`). I understand this was done to match the v1 behaviour, but I think this should have been a major version bump.

I don't think it's a good idea to change this again, as it would be another breaking change, so I've added a readme section to show how you can restore that behaviour. 

**Changes**

- Fix `toSelectArray` breaking change by reinstating method (but marking is as deprecated)
- Add readme documentation of returning previous v2 `toArray` behaviour. 

**Breaking changes**

None.

Resolves https://github.com/BenSampo/laravel-enum/issues/170