### PR TITLE
Using the assertEquals to make value equals strict

### DIFF
--- a/tests/EnumKeyTest.php
+++ b/tests/EnumKeyTest.php
@@ -42,6 +42,6 @@ class EnumKeyTest extends TestCase
     {
         $rule = new EnumKey(UserType::class);
         
-        $this->assertEquals('enum_key:' . UserType::class, (string) $rule);
+        $this->assertSame('enum_key:' . UserType::class, (string) $rule);
     }
 }

--- a/tests/EnumLocalizationTest.php
+++ b/tests/EnumLocalizationTest.php
@@ -9,18 +9,18 @@ class EnumLocalizationTest extends ApplicationTestCase
     public function test_enum_get_description_with_localization()
     {
         $this->app->setLocale('en');
-        $this->assertEquals('Super administrator', UserTypeLocalized::getDescription(UserTypeLocalized::SuperAdministrator));
+        $this->assertSame('Super administrator', UserTypeLocalized::getDescription(UserTypeLocalized::SuperAdministrator));
 
         $this->app->setLocale('es');
-        $this->assertEquals('Súper administrador', UserTypeLocalized::getDescription(UserTypeLocalized::SuperAdministrator));
+        $this->assertSame('Súper administrador', UserTypeLocalized::getDescription(UserTypeLocalized::SuperAdministrator));
     }
 
     public function test_enum_get_description_for_missing_localization_key()
     {
         $this->app->setLocale('en');
-        $this->assertEquals('Moderator', UserTypeLocalized::getDescription(UserTypeLocalized::Moderator));
+        $this->assertSame('Moderator', UserTypeLocalized::getDescription(UserTypeLocalized::Moderator));
 
         $this->app->setLocale('es');
-        $this->assertEquals('Moderator', UserTypeLocalized::getDescription(UserTypeLocalized::Moderator));
+        $this->assertSame('Moderator', UserTypeLocalized::getDescription(UserTypeLocalized::Moderator));
     }
 }

--- a/tests/EnumTest.php
+++ b/tests/EnumTest.php
@@ -12,8 +12,8 @@ class EnumTest extends TestCase
 {
     public function test_enum_values()
     {
-        $this->assertEquals(0, UserType::Administrator);
-        $this->assertEquals(3, UserType::SuperAdministrator);
+        $this->assertSame(0, UserType::Administrator);
+        $this->assertSame(3, UserType::SuperAdministrator);
     }
 
     public function test_enum_get_keys()
@@ -27,10 +27,10 @@ class EnumTest extends TestCase
     public function test_enum_coerce()
     {
         $enum = UserType::coerce(UserType::Administrator()->value);
-        $this->assertEquals(UserType::Administrator, $enum->value);
+        $this->assertSame(UserType::Administrator, $enum->value);
 
         $enum = UserType::coerce(UserType::Administrator()->key);
-        $this->assertEquals(UserType::Administrator, $enum->value);
+        $this->assertSame(UserType::Administrator, $enum->value);
 
         $enum = UserType::coerce(-1);
         $this->assertEquals(null, $enum);
@@ -49,33 +49,33 @@ class EnumTest extends TestCase
 
     public function test_enum_get_key()
     {
-        $this->assertEquals('Moderator', UserType::getKey(1));
-        $this->assertEquals('SuperAdministrator', UserType::getKey(3));
+        $this->assertSame('Moderator', UserType::getKey(1));
+        $this->assertSame('SuperAdministrator', UserType::getKey(3));
     }
 
     public function test_enum_get_key_using_string_value()
     {
-        $this->assertEquals('Administrator', StringValues::getKey('administrator'));
+        $this->assertSame('Administrator', StringValues::getKey('administrator'));
     }
 
     public function test_enum_get_value()
     {
-        $this->assertEquals(1, UserType::getValue('Moderator'));
-        $this->assertEquals(3, UserType::getValue('SuperAdministrator'));
+        $this->assertSame(1, UserType::getValue('Moderator'));
+        $this->assertSame(3, UserType::getValue('SuperAdministrator'));
     }
 
     public function test_enum_get_value_using_string_key()
     {
-        $this->assertEquals('administrator', StringValues::getValue('Administrator'));
+        $this->assertSame('administrator', StringValues::getValue('Administrator'));
     }
 
     public function test_enum_get_description()
     {
-        $this->assertEquals('Normal', MixedKeyFormats::getDescription(MixedKeyFormats::Normal));
-        $this->assertEquals('Multi word key name', MixedKeyFormats::getDescription(MixedKeyFormats::MultiWordKeyName));
-        $this->assertEquals('Uppercase', MixedKeyFormats::getDescription(MixedKeyFormats::UPPERCASE));
-        $this->assertEquals('Uppercase snake case', MixedKeyFormats::getDescription(MixedKeyFormats::UPPERCASE_SNAKE_CASE));
-        $this->assertEquals('Lowercase snake case', MixedKeyFormats::getDescription(MixedKeyFormats::lowercase_snake_case));
+        $this->assertSame('Normal', MixedKeyFormats::getDescription(MixedKeyFormats::Normal));
+        $this->assertSame('Multi word key name', MixedKeyFormats::getDescription(MixedKeyFormats::MultiWordKeyName));
+        $this->assertSame('Uppercase', MixedKeyFormats::getDescription(MixedKeyFormats::UPPERCASE));
+        $this->assertSame('Uppercase snake case', MixedKeyFormats::getDescription(MixedKeyFormats::UPPERCASE_SNAKE_CASE));
+        $this->assertSame('Lowercase snake case', MixedKeyFormats::getDescription(MixedKeyFormats::lowercase_snake_case));
     }
 
     public function test_enum_get_random_key()
@@ -181,6 +181,6 @@ class EnumTest extends TestCase
 
     public function test_enum_can_be_json_encoded()
     {
-        $this->assertEquals('1', json_encode(UserType::Moderator()));
+        $this->assertSame('1', json_encode(UserType::Moderator()));
     }
 }

--- a/tests/EnumValidationTest.php
+++ b/tests/EnumValidationTest.php
@@ -39,6 +39,6 @@ class EnumValidationTest extends TestCase
     {
         $rule = new Enum(UserType::class);
         
-        $this->assertEquals('enum:' . UserType::class, (string) $rule);
+        $this->assertSame('enum:' . UserType::class, (string) $rule);
     }
 }

--- a/tests/EnumValueTest.php
+++ b/tests/EnumValueTest.php
@@ -95,13 +95,13 @@ class EnumValueTest extends TestCase
     {
         $rule = new EnumValue(UserType::class, false);
     
-        $this->assertEquals('enum_value:' . UserType::class . ',false', (string) $rule);
+        $this->assertSame('enum_value:' . UserType::class . ',false', (string) $rule);
     }
     
     public function test_can_serialize_to_string_with_strict_type_checking()
     {
         $rule = new EnumValue(UserType::class, true);
         
-        $this->assertEquals('enum_value:' . UserType::class . ',true', (string) $rule);
+        $this->assertSame('enum_value:' . UserType::class . ',true', (string) $rule);
     }
 }

--- a/tests/FlaggedEnumTest.php
+++ b/tests/FlaggedEnumTest.php
@@ -175,9 +175,9 @@ class FlaggedEnumTest extends TestCase
     public function test_can_get_bitmask_for_an_instance()
     {
         $powers = new SuperPowers([SuperPowers::Strength, SuperPowers::Flight]);
-        $this->assertEquals(1001, $powers->getBitmask());
+        $this->assertSame(1001, $powers->getBitmask());
 
-        $this->assertEquals(1101, SuperPowers::Superman()->getBitmask());
+        $this->assertSame(1101, SuperPowers::Superman()->getBitmask());
     }
 
     public function test_can_instantiate_a_flagged_enum_from_a_value_which_has_multiple_flags_set()

--- a/tests/PHPStanTest.php
+++ b/tests/PHPStanTest.php
@@ -74,7 +74,7 @@ class PHPStanTest extends TestCase
         $method = $this->getMethodReflection(AnnotatedConstants::class, 'InternalDeprecated');
 
         $deprecatedDescription = $method->getDeprecatedDescription();
-        $this->assertEquals('1.0 Deprecation description', $deprecatedDescription);
+        $this->assertSame('1.0 Deprecation description', $deprecatedDescription);
     }
 
     public function test_internal_constant_static_method_is_internal(): void
@@ -98,7 +98,7 @@ class PHPStanTest extends TestCase
         $method = $this->getMethodReflection(AnnotatedConstants::class, 'Deprecated');
 
         $deprecatedDescription = $method->getDeprecatedDescription();
-        $this->assertEquals('', $deprecatedDescription);
+        $this->assertNull($deprecatedDescription);
     }
 
     public function test_unannotated_constant_static_method_is_not_internal_and_not_deprecated(): void


### PR DESCRIPTION
- [x] Added or updated tests

**Related Issue/Intent**

- Using the `assertSame` to make assert value equals strict.
- Using the `assertNull` to assert value is `null`.