### PR TITLE
Support PHP 8.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        php: [7.3, 7.4]
+        php: ['7.3', '7.4', '8.0']
         dependency-version: [prefer-lowest, prefer-stable]
 
     name: P${{ matrix.php }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}

--- a/composer.json
+++ b/composer.json
@@ -19,17 +19,18 @@
         }
     ],
     "require": {
-        "php": "^7.3",
-        "hanneskod/classtools": "~1.0",
-        "illuminate/support": "^8.0",
+        "php": "^7.3|^8.0",
+        "hanneskod/classtools": "^1.2",
         "illuminate/contracts": "^8.0",
-        "laminas/laminas-code": "^3.4"
+        "illuminate/support": "^8.0",
+        "laminas/laminas-code": "^3.4",
+        "nikic/php-parser": "^4.10"
     },
     "require-dev": {
         "doctrine/dbal": "^2.9",
-        "laravel/framework": "^8.0",
         "orchestra/testbench": "^6.0",
-        "phpstan/phpstan": "^0.12.9",
+        "mockery/mockery": "^1.4",
+        "phpstan/phpstan": "^0.12.59",
         "phpunit/phpunit": "^8.5",
         "squizlabs/php_codesniffer": "^3.0"
     },


### PR DESCRIPTION
- [ ] Added or updated tests
- [ ] Added or updated the [README.md](../README.md)
- [ ] Detailed changes in the [CHANGELOG.md](../CHANGELOG.md) unreleased section

**Changes**

This pull request let this package support PHP 8.0.

Because there is `prefer-lowest` testing matrix, to solve testing error, there are two new dependence requirements. (`nikic/php-parser` and `mockery/mockery`)

Without `prefer-lowest` testing matrix, these new dependencies are not required.