### PR TITLE
Allow custom validation error message for each rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/BenSampo/laravel-enum/compare/v3.1.0...master)
+## [Unreleased](https://github.com/BenSampo/laravel-enum/compare/v3.2.0...master)
+
+### Added
+
+- Allow custom validation error message for each rules by passing an optional last parameter of each rules class
 
 ## [3.2.0](https://github.com/BenSampo/laravel-enum/compare/v3.1.0...v3.2.0) - 2020-12-15
 

--- a/README.md
+++ b/README.md
@@ -620,6 +620,12 @@ By default, type checking is set to strict, but you can bypass this by passing `
 new EnumValue(UserType::class, false) // Turn off strict type checking.
 ```
 
+You may pass an optional third parameter to set a custom error message when the validation failed. This is useful if you want to create a dynamic error message and/or you don't want to override the localization files.
+
+```php
+new EnumValue(UserType::class, true, "This is the custom error message")
+```
+
 #### Enum key
 
 You can also validate on keys using the `EnumKey` rule. This is useful if you're taking the enum key as a URL parameter for sorting or filtering for example.
@@ -635,6 +641,12 @@ public function store(Request $request)
 }
 ```
 
+You may pass an optional second parameter to set a custom error message when the validation failed. This is useful if you want to create a dynamic error message and/or you don't want to override the localization files.
+
+```php
+new EnumKey(UserType::class, "This is the custom error message")
+```
+
 #### Enum instance
 
 Additionally you can validate that a parameter is an instance of a given enum.
@@ -648,6 +660,12 @@ public function store(Request $request)
         'user_type' => ['required', new Enum(UserType::class)],
     ]);
 }
+```
+
+You may pass an optional second parameter to set a custom error message when the validation failed. This is useful if you want to create a dynamic error message and/or you don't want to override the localization files.
+
+```php
+new Enum(UserType::class, "This is the custom error message")
 ```
 
 ### Pipe Validation

--- a/src/Rules/Enum.php
+++ b/src/Rules/Enum.php
@@ -17,16 +17,23 @@ class Enum implements Rule
     protected $enumClass;
 
     /**
+     * @var string
+     */
+    protected $message;
+
+    /**
      * Create a new rule instance.
      *
      * @param  string  $enum
+     * @param  string  $message
      * @return void
      *
      * @throws \InvalidArgumentException
      */
-    public function __construct(string $enum)
+    public function __construct(string $enum, string $message = null)
     {
         $this->enumClass = $enum;
+        $this->message = $message;
 
         if (! class_exists($this->enumClass)) {
             throw new \InvalidArgumentException("Cannot validate against the enum, the class {$this->enumClass} doesn't exist.");
@@ -52,7 +59,7 @@ class Enum implements Rule
      */
     public function message()
     {
-        return __('laravelEnum::messages.enum');
+        return $this->message ?: __('laravelEnum::messages.enum');
     }
 
     /**

--- a/src/Rules/EnumKey.php
+++ b/src/Rules/EnumKey.php
@@ -17,16 +17,23 @@ class EnumKey implements Rule
     protected $enumClass;
 
     /**
+     * @var string
+     */
+    protected $message;
+
+    /**
      * Create a new rule instance.
      *
      * @param  string  $enum
+     * @param  string  $message
      * @return void
      *
      * @throws \InvalidArgumentException
      */
-    public function __construct(string $enum)
+    public function __construct(string $enum, string $message = null)
     {
         $this->enumClass = $enum;
+        $this->message = $message;
 
         if (! class_exists($this->enumClass)) {
             throw new \InvalidArgumentException("Cannot validate against the enum, the class {$this->enumClass} doesn't exist.");
@@ -52,7 +59,7 @@ class EnumKey implements Rule
      */
     public function message()
     {
-        return __('laravelEnum::messages.enum_key');
+        return $this->message ?: __('laravelEnum::messages.enum_key');
     }
 
     /**

--- a/src/Rules/EnumValue.php
+++ b/src/Rules/EnumValue.php
@@ -23,18 +23,25 @@ class EnumValue implements Rule
     protected $strict;
 
     /**
+     * @var string
+     */
+    protected $message;
+
+    /**
      * Create a new rule instance.
      *
      * @param  string  $enumClass
      * @param  bool  $strict
+     * @param  string  $message
      * @return void
      *
      * @throws \InvalidArgumentException
      */
-    public function __construct(string $enumClass, bool $strict = true)
+    public function __construct(string $enumClass, bool $strict = true, string $message = null)
     {
         $this->enumClass = $enumClass;
         $this->strict = $strict;
+        $this->message = $message;
 
         if (! class_exists($this->enumClass)) {
             throw new \InvalidArgumentException("Cannot validate against the enum, the class {$this->enumClass} doesn't exist.");
@@ -68,7 +75,7 @@ class EnumValue implements Rule
      */
     public function message()
     {
-        return __('laravelEnum::messages.enum_value');
+        return $this->message ?: __('laravelEnum::messages.enum_value');
     }
 
     /**

--- a/tests/EnumKeyTest.php
+++ b/tests/EnumKeyTest.php
@@ -31,6 +31,14 @@ class EnumKeyTest extends TestCase
         $this->assertFalse($fails3);
     }
 
+    public function test_custom_validation_message_is_set()
+    {
+        $expected = 'EnumKey custom validation message';
+        $message = (new EnumKey(UserType::class, $expected))->message();
+
+        $this->assertSame($expected, $message);
+    }
+
     public function test_an_exception_is_thrown_if_an_non_existing_class_is_passed()
     {
         $this->expectException(\InvalidArgumentException::class);

--- a/tests/EnumValidationTest.php
+++ b/tests/EnumValidationTest.php
@@ -28,6 +28,14 @@ class EnumValidationTest extends TestCase
         $this->assertFalse($fails4);
     }
 
+    public function test_custom_validation_message_is_set()
+    {
+        $expected = 'EnumKey custom validation message';
+        $message = (new Enum(UserType::class, $expected))->message();
+
+        $this->assertSame($expected, $message);
+    }
+
     public function test_an_exception_is_thrown_if_an_non_existing_class_is_passed()
     {
         $this->expectException(\InvalidArgumentException::class);

--- a/tests/EnumValueTest.php
+++ b/tests/EnumValueTest.php
@@ -30,6 +30,14 @@ class EnumValueTest extends TestCase
         $this->assertFalse($fails3);
     }
 
+    public function test_custom_validation_message_is_set()
+    {
+        $expected = 'EnumKey custom validation message';
+        $message = (new EnumValue(UserType::class, true, $expected))->message();
+
+        $this->assertSame($expected, $message);
+    }
+
     public function test_flagged_enum_passes_with_no_flags_set()
     {
         $passed = (new EnumValue(SuperPowers::class))->passes('', 0);


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Added or updated the [README.md](../README.md)
- [x] Detailed changes in the [CHANGELOG.md](../CHANGELOG.md) unreleased section

**Related Issue/Intent**
None

**Changes**

This will allow us to set a custom validation error message when declaring a validation rules in a specific controller without having to change the error message for all instances by overriding the localization files in `resources/lang`.

The usage example:
```php
$validator = Validator::make($request->all(), [
    'source' => ['required', new EnumValue(Source::class, true, 'The value must be one of: ' . implode(', ', Source::getValues()))],
]);
```

**Breaking changes**

Each rules class constructor changed to accept an optional last parameter. Any derived classes will need to update their constructor signature to match the updated rules class.
But, this is should be a rare case and should not be a problem for majority of users.
