### PR TITLE
Fixing issue for descriptions with uppercase keys and numeric suffix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/BenSampo/laravel-enum/compare/v3.1.0...master)
 
+### Fixed
+- Fixed issue in `getFriendlyKeyName`when uppercase key contains non-alpha characters [#210](https://github.com/BenSampo/laravel-enum/pull/210)
+
 ## [3.2.0](https://github.com/BenSampo/laravel-enum/compare/v3.1.0...v3.2.0) - 2020-12-15
 
 ### Added

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -443,7 +443,7 @@ abstract class Enum implements EnumContract, Castable, Arrayable, JsonSerializab
      */
     protected static function getFriendlyKeyName(string $key): string
     {
-        if (ctype_upper(str_replace('_', '', $key))) {
+        if (ctype_upper(preg_replace('/[^a-zA-Z]/', '', $key))) {
             $key = strtolower($key);
         }
 

--- a/tests/EnumTest.php
+++ b/tests/EnumTest.php
@@ -76,6 +76,8 @@ class EnumTest extends TestCase
         $this->assertSame('Uppercase', MixedKeyFormats::getDescription(MixedKeyFormats::UPPERCASE));
         $this->assertSame('Uppercase snake case', MixedKeyFormats::getDescription(MixedKeyFormats::UPPERCASE_SNAKE_CASE));
         $this->assertSame('Lowercase snake case', MixedKeyFormats::getDescription(MixedKeyFormats::lowercase_snake_case));
+        $this->assertSame('Uppercase snake case numeric suffix 2', MixedKeyFormats::getDescription(MixedKeyFormats::UPPERCASE_SNAKE_CASE_NUMERIC_SUFFIX_2));
+        $this->assertSame('Lowercase snake case numeric suffix 2', MixedKeyFormats::getDescription(MixedKeyFormats::lowercase_snake_case_numeric_suffix_2));
     }
 
     public function test_enum_get_random_key()

--- a/tests/Enums/MixedKeyFormats.php
+++ b/tests/Enums/MixedKeyFormats.php
@@ -11,4 +11,6 @@ final class MixedKeyFormats extends Enum
     const UPPERCASE = 3;
     const UPPERCASE_SNAKE_CASE = 4;
     const lowercase_snake_case = 5;
+    const UPPERCASE_SNAKE_CASE_NUMERIC_SUFFIX_2 = 6;
+    const lowercase_snake_case_numeric_suffix_2 = 7;
 }


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Added or updated the [README.md](../README.md)
- [x] Detailed changes in the [CHANGELOG.md](../CHANGELOG.md) unreleased section

**Related Issue/Intent**

Resolves #209

**Changes**

There is a check in the `getFriendlyKeyName` function which determines if a key is all uppercase, however this doesn't work if the key contains non-alpha characters so I've updated it to work in that scenario and added the additional test cases
