### PR TITLE
Allow passing iterables to Enum::in()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/BenSampo/laravel-enum/compare/v3.1.0...master)
 
+### Changed
+
+- Allow passing iterables to Enum::in() [#212](https://github.com/BenSampo/laravel-enum/pull/212)
+
 ## [3.2.0](https://github.com/BenSampo/laravel-enum/compare/v3.1.0...v3.2.0) - 2020-12-15
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ $admin->is(UserType::Moderator());     // false
 $admin->is('random-value');            // false
 ```
 
-You can also check to see if the instance's value matches against an array of possible values using the `in` method.
+You can also check to see if the instance's value matches against an array of possible values using the `in` method. Iterables can also be checked against.
 
 ```php
 $admin = UserType::fromValue(UserType::Administrator);

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -187,7 +187,7 @@ abstract class Enum implements EnumContract, Castable, Arrayable, JsonSerializab
      * @param  (mixed|static)[]  $values
      * @return bool
      */
-    public function in(array $values): bool
+    public function in(iterable $values): bool
     {
         foreach ($values as $value) {
             if ($this->is($value)) {

--- a/tests/EnumComparisonTest.php
+++ b/tests/EnumComparisonTest.php
@@ -2,6 +2,7 @@
 
 namespace BenSampo\Enum\Tests;
 
+use ArrayIterator;
 use BenSampo\Enum\Tests\Enums\IntegerValues;
 use BenSampo\Enum\Tests\Enums\StringValues;
 use BenSampo\Enum\Tests\Enums\UserType;
@@ -63,6 +64,22 @@ class EnumComparisonTest extends TestCase
         ]));
         $this->assertTrue($administrator->in([StringValues::Administrator]));
         $this->assertFalse($administrator->in([StringValues::Moderator]));
+    }
+
+    public function test_enum_instance_in_iterator()
+    {
+        $administrator = new StringValues(StringValues::Administrator);
+
+        $this->assertTrue($administrator->in(new ArrayIterator([
+            StringValues::Moderator,
+            StringValues::Administrator
+        ])));
+        $this->assertTrue($administrator->in(new ArrayIterator([
+            new StringValues(StringValues::Moderator),
+            new StringValues(StringValues::Administrator)
+        ])));
+        $this->assertTrue($administrator->in(new ArrayIterator([StringValues::Administrator])));
+        $this->assertFalse($administrator->in(new ArrayIterator([StringValues::Moderator])));
     }
 
     /**


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Added or updated the [README.md](../README.md)
- [x] Detailed changes in the [CHANGELOG.md](../CHANGELOG.md) unreleased section

**Related Issue/Intent**

I often have to deal with enums in collections. Having to cast said collections back to array when using the `in()` method is mildly inconvenient.

**Changes**

This PR changes the signature of `in()` to accept an `iterable` instead of an `array`.

**Breaking changes**

None
