### PR TITLE
Fix validation error message localization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/BenSampo/laravel-enum/compare/v3.4.2...master)
 
+### Fixed
+
+- Fixed validation error message localization when using string validation rules [#227](https://github.com/BenSampo/laravel-enum/pull/227)
+
 ## [3.4.2](https://github.com/BenSampo/laravel-enum/compare/v3.4.1...v3.4.2) - 2021-09-09
 
 ### Fixed

--- a/resources/lang/en/messages.php
+++ b/resources/lang/en/messages.php
@@ -1,7 +1,7 @@
 <?php
 
 return [
-    'enum' => __('The value you have provided is not a valid enum instance.'),
-    'enum_value' => __('The value you have entered is invalid.'),
-    'enum_key' => __('The key you have entered is invalid.'),
+    'enum' => 'The value you have provided is not a valid enum instance.',
+    'enum_value' => 'The value you have entered is invalid.',
+    'enum_key' => 'The key you have entered is invalid.',
 ];

--- a/src/EnumServiceProvider.php
+++ b/src/EnumServiceProvider.php
@@ -57,7 +57,7 @@ class EnumServiceProvider extends ServiceProvider
             $enum = $parameters[0] ?? null;
 
             return (new EnumKey($enum))->passes($attribute, $value);
-        });
+        }, __('laravelEnum::messages.enum_key'));
 
         $this->app['validator']->extend('enum_value', function ($attribute, $value, $parameters, $validator) {
             $enum = $parameters[0] ?? null;
@@ -71,13 +71,13 @@ class EnumServiceProvider extends ServiceProvider
             $strict = !! json_decode(strtolower($strict));
 
             return (new EnumValue($enum, $strict))->passes($attribute, $value);
-        });
+        }, __('laravelEnum::messages.enum_value'));
 
         $this->app['validator']->extend('enum', function ($attribute, $value, $parameters, $validator) {
             $enum = $parameters[0] ?? null;
 
             return (new Enum($enum))->passes($attribute, $value);
-        });
+        }, __('laravelEnum::messages.enum'));
     }
 
     /**

--- a/src/Rules/Enum.php
+++ b/src/Rules/Enum.php
@@ -52,7 +52,9 @@ class Enum implements Rule
      */
     public function message()
     {
-        return __('laravelEnum::messages.enum');
+        return trans()->has('validation.enum')
+            ? __('validation.enum')
+            : __('laravelEnum::messages.enum');
     }
 
     /**

--- a/src/Rules/EnumKey.php
+++ b/src/Rules/EnumKey.php
@@ -52,7 +52,9 @@ class EnumKey implements Rule
      */
     public function message()
     {
-        return __('laravelEnum::messages.enum_key');
+        return trans()->has('validation.enum_key')
+            ? __('validation.enum_key')
+            : __('laravelEnum::messages.enum_key');
     }
 
     /**

--- a/src/Rules/EnumValue.php
+++ b/src/Rules/EnumValue.php
@@ -68,7 +68,9 @@ class EnumValue implements Rule
      */
     public function message()
     {
-        return __('laravelEnum::messages.enum_value');
+        return trans()->has('validation.enum_value')
+            ? __('validation.enum_value')
+            : __('laravelEnum::messages.enum_value');
     }
 
     /**

--- a/tests/EnumLocalizationTest.php
+++ b/tests/EnumLocalizationTest.php
@@ -58,22 +58,22 @@ class EnumLocalizationTest extends ApplicationTestCase
 
         $this->assertSame(
             'The value you have provided is not a valid enum instance.',
-            $validator->make(['input' => 'test'], ['input' => 'enum:' . UserType::class])->errors()->first()
+            $validator->make(['input' => 'test'], ['input' => 'enum:BenSampo\Enum\Tests\Enums\UserType'])->errors()->first()
         );
         $this->assertSame(
             'Wrong key.',
-            $validator->make(['input' => 'test'], ['input' => 'enum_key:' . UserType::class])->errors()->first()
+            $validator->make(['input' => 'test'], ['input' => 'enum_key:BenSampo\Enum\Tests\Enums\UserType'])->errors()->first()
         );
 
         $this->app->setLocale('es');
 
         $this->assertSame(
             'The value you have provided is not a valid enum instance.', // No Spanish translations out of the box
-            $validator->make(['input' => 'test'], ['input' => 'enum:' . UserType::class])->errors()->first()
+            $validator->make(['input' => 'test'], ['input' => 'enum:BenSampo\Enum\Tests\Enums\UserType'])->errors()->first()
         );
         $this->assertSame(
             'Llave incorrecta.',
-            $validator->make(['input' => 'test'], ['input' => 'enum_key:' . UserType::class])->errors()->first()
+            $validator->make(['input' => 'test'], ['input' => 'enum_key:BenSampo\Enum\Tests\Enums\UserType'])->errors()->first()
         );
     }
 }

--- a/tests/EnumLocalizationTest.php
+++ b/tests/EnumLocalizationTest.php
@@ -2,6 +2,9 @@
 
 namespace BenSampo\Enum\Tests;
 
+use BenSampo\Enum\Rules\Enum;
+use BenSampo\Enum\Rules\EnumKey;
+use BenSampo\Enum\Tests\Enums\UserType;
 use BenSampo\Enum\Tests\Enums\UserTypeLocalized;
 
 class EnumLocalizationTest extends ApplicationTestCase
@@ -22,5 +25,55 @@ class EnumLocalizationTest extends ApplicationTestCase
 
         $this->app->setLocale('es');
         $this->assertSame('Moderator', UserTypeLocalized::getDescription(UserTypeLocalized::Moderator));
+    }
+
+    public function test_can_localize_validation_error_message_using_class_rule()
+    {
+        $validator = $this->app['validator'];
+
+        $this->assertSame(
+            'The value you have provided is not a valid enum instance.',
+            $validator->make(['input' => 'test'], ['input' => new Enum(UserType::class)])->errors()->first()
+        );
+        $this->assertSame(
+            'Wrong key.',
+            $validator->make(['input' => 'test'], ['input' => new EnumKey(UserType::class)])->errors()->first()
+        );
+
+        $this->app->setLocale('es');
+
+        $this->assertSame(
+            'The value you have provided is not a valid enum instance.', // No Spanish translations out of the box
+            $validator->make(['input' => 'test'], ['input' => new Enum(UserType::class)])->errors()->first()
+        );
+        $this->assertSame(
+            'Llave incorrecta.',
+            $validator->make(['input' => 'test'], ['input' => new EnumKey(UserType::class)])->errors()->first()
+        );
+    }
+
+    public function test_can_localize_validation_error_message_using_string_rule()
+    {
+        $validator = $this->app['validator'];
+
+        $this->assertSame(
+            'The value you have provided is not a valid enum instance.',
+            $validator->make(['input' => 'test'], ['input' => 'enum:' . UserType::class])->errors()->first()
+        );
+        $this->assertSame(
+            'Wrong key.',
+            $validator->make(['input' => 'test'], ['input' => 'enum_key:' . UserType::class])->errors()->first()
+        );
+
+        $this->app->setLocale('es');
+
+        $this->assertSame(
+            'The value you have provided is not a valid enum instance.', // No Spanish translations out of the box
+            $validator->make(['input' => 'test'], ['input' => 'enum:' . UserType::class])->errors()->first()
+        );
+        $this->assertSame(
+            'Llave incorrecta.',
+            $validator->make(['input' => 'test'], ['input' => 'enum_key:' . UserType::class])->errors()->first()
+        );
     }
 }

--- a/tests/lang/en/validation.php
+++ b/tests/lang/en/validation.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    'enum_key' => 'Wrong key.',
+];

--- a/tests/lang/es/validation.php
+++ b/tests/lang/es/validation.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    'enum_key' => 'Llave incorrecta.',
+];


### PR DESCRIPTION
- [x] Added or updated tests
- [x] ~Added or updated the [README.md](../README.md)~ n/a
- [x] Detailed changes in the [CHANGELOG.md](../CHANGELOG.md) unreleased section

### Related Issue/Intent

Ensures it is easy to customize/localize validation error messages when using the validation rules as classes **or** as strings.

This PR reverts #141, which reintroduced the issue in #133 where using the validation rules as strings (e.g. `enum_value:UserType`) prevented error messages from being displayed properly. #141 didn't really have any explanation of its changes, but what I think it was _trying_ to do was allow users to easily customize the error messages for this package's validation rules. It implemented this the wrong way though, localizing the message strings themselves directly inside the language file. This has a few disadvantages:

- to translate the messages you would have to re-translate the string by adding `"The value you have provided is not a valid enum instance.": "Translation..."` in a JSON translation file
- it will translate/override that exact string everywhere it appears in the app, not just in validation errors
- it prevents customizing the validation error message for specific attributes or enums (you can't set new messages in any `validation.php` file)
- it removed localization of error messages for string rules, breaking the default error messages for something like `enum_value:UserType`

### Changes

This PR re-implements localization of validation error messages.

It allows this package's validation error messages to be translated by adding `enum`, `enum_key`, and `enum_value` keys to the `en/validation.php` file that ships with Laravel, and the corresponding files for any other locales.

It also allows further customizing the messages for specific cases by adding entries to the `custom` key in that file, e.g.:

```php
    'custom' => [
        'user_type' => [
            'enum_value' => 'The user type you have entered is invalid.',
        ],
    ]
```

### Notes

The reason the `trans()->has()` check in the rules is necessary is that Laravel handles validation error messages _completely_ separately for custom rule classes and for string rules added with `Validator::extend()`.

For string rules, the third argument to `Validator::extend()` is treated as a fallback. If a language file entry for the snake-cased rule name exists, that will be used, otherwise the fallback will be used ([source](https://github.com/laravel/framework/blob/b1004f2ae8c41ae7b398e343964ab85cb905636d/src/Illuminate/Validation/Concerns/FormatsMessages.php#L14-L64)). This worked fine before #141 and still does if you manually add all the keys to your lang files, but #141 breaks it out of the box. This PR makes it work by default again, without users needing to add any language lines themselves.

For class rules, the `messages()` method is the single source of truth—Laravel's validator doesn't check for custom language file entries for the key at all ([source](https://github.com/laravel/framework/blob/b1004f2ae8c41ae7b398e343964ab85cb905636d/src/Illuminate/Validation/Validator.php#L738-L769)). This PR adds a check to see if any custom keys have been defined, so they'll be used instead when possible, and otherwise falls back to the ones provided by the package.