### PR TITLE
Improve enum anotate compatibility with Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/BenSampo/laravel-enum/compare/v3.4.2...master)
 
+### Fixed
+
+- Fixed broken enum anotation with Windows line endings [#228](https://github.com/BenSampo/laravel-enum/pull/228)
+
 ## [3.4.2](https://github.com/BenSampo/laravel-enum/compare/v3.4.1...v3.4.2) - 2021-09-09
 
 ### Fixed

--- a/src/Commands/AbstractAnnotationCommand.php
+++ b/src/Commands/AbstractAnnotationCommand.php
@@ -129,7 +129,7 @@ abstract class AbstractAnnotationCommand extends Command
 
         // Remove existing docblock
         $contents = preg_replace(
-            sprintf('#([\n]?\/\*(?:[^*]|\n|(?:\*(?:[^\/]|\n)))*\*\/)?[\n]?%s#ms', preg_quote($classDeclaration)),
+            sprintf('#(\r?\n\/\*.*?\*\/)?\v*%s#ms', preg_quote($classDeclaration)),
             "\n" . $classDeclaration,
             $contents
         );


### PR DESCRIPTION
Hi,

- [ ] Added or updated tests
- [ ] Added or updated the [README.md](../README.md)
- [x] Detailed changes in the [CHANGELOG.md](../CHANGELOG.md) unreleased section

**Related Issue/Intent**

On Windows, when using `\r\n` line endings, the previous docblock wasn't removed properly. As a result, the same dockblock was cloned over and over each time the command was run.

**Changes**

The regexp used to remove the existing dockblock has been simplified and optionnaly detects `\r\n` line ending.

