### PR TITLE
Get all attributes feature

### DIFF
--- a/src/Enum.php
+++ b/src/Enum.php
@@ -260,6 +260,45 @@ abstract class Enum implements EnumContract, Castable, Arrayable, JsonSerializab
     }
 
     /**
+     * Get all attribute values.
+     * 
+     * @return array
+     */
+    protected static function getAttributeValues(string $attributeName): array
+    {
+        $formattedValues = [];
+        $values = static::getValues();
+        
+        foreach ($values as $value) {
+            $formattedValues[$value] = (new static($value))->{$attributeName}();
+        }
+
+        return $formattedValues;
+    }
+
+    /**
+     * Get attributes.
+     * 
+     * @return array
+     */
+    public static function getAll(string|array $attributes): array
+    {
+        if (is_string($attributes)) {
+            return static::getAttributeValues($attributes);
+        }
+
+        $values = [];
+
+        foreach (static::getValues() as $value) {
+            foreach ($attributes as $attribute) {
+                $values[$value][$attribute] = (new static($value))->{$attribute}();
+            }
+        }
+
+        return $values;
+    }
+
+    /**
      * Get all of the enum keys.
      *
      * @return array

--- a/tests/Enums/UserTypeCustomAttribute.php
+++ b/tests/Enums/UserTypeCustomAttribute.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace BenSampo\Enum\Tests\Enums;
+
+use BenSampo\Enum\Enum;
+
+final class UserTypeCustomAttribute extends Enum
+{
+    const Administrator = 0;
+    const Moderator = 1;
+    const Subscriber = 2;
+    const SuperAdministrator = 3;
+
+    public function title(): string
+    {
+        return match($this->value) {
+            static::Administrator => __('Administrator'),
+            static::Moderator => __('Moderator'),
+            static::Subscriber => __('Subscriber'),
+            static::SuperAdministrator => __('Super Administrator'),
+        };
+    }
+
+    public function tagColor(): string
+    {
+        return match($this->value) {
+            static::Administrator => 'green',
+            static::Moderator => 'orange',
+            static::Subscriber => 'black',
+            static::SuperAdministrator => 'red',
+        };
+    }
+}


### PR DESCRIPTION
- [x] Added example class
- [ ] Added or updated tests
- [ ] Added or updated the [README.md](../README.md)
- [ ] Detailed changes in the [CHANGELOG.md](../CHANGELOG.md) unreleased section

**Changes**

With this feature, you can create custom attributes and get all statically.

Examples:
```php
<?php

namespace App\Enums;

use BenSampo\Enum\Enum;

/**
 * @method static Pending()
 * @method static Delivered()
 * @method static Readed()
 */
final class MessageStatusEnum extends Enum
{
    const Pending = 1;
    const Delivered = 2;
    const Readed = 3;

    public function title(): string
    {
        return match ($this->value) {
            self::Pending => __('Pending'),
            self::Delivered => __('Delivered'),
            self::Readed => __('Readed'),
        };
    }

    public function color(): string
    {
        return match ($this->value) {
            self::Pending => 'gray',
            self::Delivered => 'orange',
            self::Readed => 'green',
        };
    }
}
```

Using:
```php
<?php

$message = new Message(['status' => 1]);

echo $message->status->title();
// Pending

print_r(MessageStatusEnum::getAll('title'));
// [1 => 'Pending', 2 => 'Delivered', 3 => 'Readed']

print_r(MessageStatusEnum::getAll(['title', 'color']));
// [
//     1 => [
//         'title' => 'Pending',
//         'color' => 'gray'
//     ],
//     2 => [
//         'title' => 'Delivered',
//         'color' => 'orange'
//     ],
//     3 => [
//         'title' => 'Readed',
//         'color' => 'green'
//     ],
// ]