### PR TITLE
Ensure compatibility with PHP 8.1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,8 +9,11 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        php: ['7.3', '7.4', '8.0', '8.1']
+        php: [7.3, 7.4, 8.0, 8.1]
         dependency-version: [prefer-lowest, prefer-stable]
+        exclude:
+          - php-version: 8.1
+            dependency-version: prefer-lowest
 
     name: P${{ matrix.php }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
         php: [7.3, 7.4, 8.0, 8.1]
         dependency-version: [prefer-lowest, prefer-stable]
         exclude:
-          - php-version: 8.1
+          - php: 8.1
             dependency-version: prefer-lowest
 
     name: P${{ matrix.php }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        php: ['7.3', '7.4', '8.0']
+        php: ['7.3', '7.4', '8.0', '8.1']
         dependency-version: [prefer-lowest, prefer-stable]
 
     name: P${{ matrix.php }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/BenSampo/laravel-enum/compare/v4.0.0...master)
 
+### Added
+
+- Allow package to be installed with PHP 8.1
+
+### Changed
+
+- Allow `laminas/laminas-code:^4.0` as a dependency
+
 ## [4.0.0](https://github.com/BenSampo/laravel-enum/compare/v3.4.2...v4.0.0) - 2021-11-09
 
 ### Fixed

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "orchestra/testbench": "^6.2",
         "mockery/mockery": "^1.4",
         "phpstan/phpstan": "^0.12.59",
-        "phpunit/phpunit": "^8.5",
+        "phpunit/phpunit": "^8.5.21",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "hanneskod/classtools": "^1.2",
         "illuminate/contracts": "^8.0",
         "illuminate/support": "^8.0",
-        "laminas/laminas-code": "^3.4",
+        "laminas/laminas-code": "^3.4|^4.0",
         "nikic/php-parser": "^4.10"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "orchestra/testbench": "^6.2",
         "mockery/mockery": "^1.4",
         "phpstan/phpstan": "^0.12.59",
-        "phpunit/phpunit": "^8.5.21",
+        "phpunit/phpunit": "^8.5",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {


### PR DESCRIPTION
- [ ] ~Added or updated tests~
- [ ] ~Added or updated the [README.md](../README.md)~
- [x] Detailed changes in the [CHANGELOG.md](../CHANGELOG.md) unreleased section

**Related Issue/Intent**

Allows the library to be installed and used with PHP 8.1. I am currently getting the following error:

```
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - bensampo/laravel-enum[v3.2.0, ..., v3.4.2] require laminas/laminas-code ^3.4 -![image](https://user-images.githubusercontent.com/12158000/141855849-53d89947-1ad7-4424-ae50-544cdfc372d4.png)satisfiable by laminas/laminas-code[3.4.0, 3.4.1, 3.5.0, 3.5.1].
    - bensampo/laravel-enum[v1.28.3, ..., v1.38.0] require php ~7.1 -> your php version (8.1.0-dev) does not satisfy that requirement.
    - bensampo/laravel-enum[v2.0.0, ..., v2.2.0] require php ^7.2.5 -> your php version (8.1.0-dev) does not satisfy that requirement.
    - bensampo/laravel-enum[v3.0.0, ..., v3.1.0] require php ^7.3 -> your php version (8.1.0-dev) does not satisfy that requirement.
    - laminas/laminas-code[3.4.0, ..., 3.4.1] require php ^7.1 -> your php version (8.1.0-dev) does not satisfy that requirement.
    - laminas/laminas-code[3.5.0, ..., 3.5.1] require php ^7.3 || ~8.0.0 -> your php version (8.1.0-dev) does not satisfy that requirement.
    - Root composer.json requires bensampo/laravel-enum ^1.28.3 || ^2 || ^3 -> satisfiable by bensampo/laravel-enum[v1.28.3, ..., v1.38.0, v2.0.0, v2.1.0, v2.2.0, v3.0.0, ..., v3.4.2].
```

https://github.com/BenSampo/laravel-enum/issues/213 was a valid concern, but is no longer a problem.

![image](https://user-images.githubusercontent.com/12158000/141855858-394ed03e-86c3-4905-8814-faf1a719ec8a.png)

**Changes**

### Added

- Allow package to be installed with PHP 8.1

### Changed

- Allow `laminas/laminas-code:^4.0` as a dependency

**Breaking changes**

None