### PR TITLE
Suppress deprecated notice on PHP8.1

### DIFF
--- a/src/Enum.php
+++ b/src/Enum.php
@@ -571,7 +571,8 @@ abstract class Enum implements EnumContract, Castable, Arrayable, JsonSerializab
      *
      * @return mixed
      */
-    public function jsonSerialize(): mixed
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()
     {
         return $this->toArray();
     }

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -559,7 +559,7 @@ abstract class Enum implements EnumContract, Castable, Arrayable, JsonSerializab
     /**
      * Transform the enum instance when it's converted to an array.
      *
-     * @return string
+     * @return mixed
      */
     public function toArray()
     {
@@ -569,9 +569,9 @@ abstract class Enum implements EnumContract, Castable, Arrayable, JsonSerializab
     /**
      * Transform the enum when it's passed through json_encode.
      *
-     * @return string
+     * @return mixed
      */
-    public function jsonSerialize(): string
+    public function jsonSerialize(): mixed
     {
         return $this->toArray();
     }

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -571,7 +571,7 @@ abstract class Enum implements EnumContract, Castable, Arrayable, JsonSerializab
      *
      * @return string
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): string
     {
         return $this->toArray();
     }


### PR DESCRIPTION
**Related Issue/Intent**

Resolves #235 
<!-- Link to related issues this PR resolves, e.g. "Resolves #236",
or a description of what this PR is trying to achieve. -->

**Changes**

Fix following notice
> Return type of BenSampo\Enum\Enum::jsonSerialize() should either be compatible with JsonSerializable::jsonSerialize(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice

**Breaking changes**

Code is backward compatible for all currently supported php versions (^7.3|^8.0)
