### PR TITLE
Use constant PHPDoc as `Enum::$description`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/BenSampo/laravel-enum/compare/v4.1.0...master)
 
+### Added
+
+- Use constant PHPDoc as `Enum::$description`
+
 ## [4.1.0](https://github.com/BenSampo/laravel-enum/compare/v4.0.0...v4.1.0) - 2021-11-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -718,7 +718,7 @@ php artisan vendor:publish --provider="BenSampo\Enum\EnumServiceProvider" --tag=
 
 ### Enum descriptions
 
-You can translate the strings returned by the `getDescription` method using Laravel's built in [localization](https://laravel.com/docs/5.6/localization) features.
+You can translate the strings returned by the `getDescription` method using Laravel's built-in [localization](https://laravel.com/docs/localization) features.
 
 Add a new `enums.php` keys file for each of your supported languages. In this example there is one for English and one for Spanish.
 
@@ -768,22 +768,24 @@ final class UserType extends Enum implements LocalizedEnum
 
 The `getDescription` method will now look for the value in your localization files. If a value doesn't exist for a given key, the default description is returned instead.
 
-## Overriding the getDescription method
+## Customize descriptions
 
-If you'd like to return a custom value from the getDescription method, you may do so by overriding the method on your enum:
+If you'd like to return a custom value for your enum values, add a PHPDoc to your Enum constants:
 
 ```php
-public static function getDescription($value): string
-{
-    if ($value === self::SuperAdministrator) {
-        return 'Super admin';
-    }
+use BenSampo\Enum\Enum;
 
-    return parent::getDescription($value);
+final class UserType extends Enum
+{
+    /** Can do most things */
+    const Administrator = 'Administrator';
+
+    /** Can do absolutely everything */
+    const SuperAdministrator = 'SuperAdministrator';
 }
 ```
 
-Calling `UserType::getDescription(3);` now returns `Super admin` instead of `Super administator`.
+Calling `UserType::Administrator()->description` now returns `Can do most things` instead of `Administrator`.
 
 ## Extending the Enum Base Class
 
@@ -799,7 +801,7 @@ Enum::macro('asFlippedArray', function() {
 
 Now, on each of my enums, I can call it using `UserType::asFlippedArray()`.
 
-It's best to register the macro inside of a service providers' boot method.
+It's best to register the macro inside a service providers' boot method.
 
 ## Laravel Nova Integration
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 Simple, extensible and powerful enumeration implementation for Laravel.
 
 - Enum key value pairs as class constants
-- Full featured suite of methods
+- Full-featured suite of methods
 - Enum instantiation
 - Flagged/Bitwise enums
 - Type hinting

--- a/src/PHPDoc.php
+++ b/src/PHPDoc.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace BenSampo\Enum;
+
+class PHPDoc
+{
+    public static function unwrapDocblock(string $docBlock): string
+    {
+        $docBlock = substr($docBlock, 3); // strip leading /**
+        $docBlock = substr($docBlock, 0, -2); // strip trailing */
+
+        $lines = explode("\n", $docBlock);
+        $lines = array_map(function (string $line): string {
+            $line = trim($line);
+
+            $line = preg_replace('/^\* /', '$1$2', $line); // strip *
+
+            return trim($line);
+        }, $lines);
+
+        return trim(implode("\n", $lines));
+    }
+}

--- a/tests/EnumDescriptionTest.php
+++ b/tests/EnumDescriptionTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace BenSampo\Enum\Tests;
+
+use BenSampo\Enum\Tests\Enums\Described;
+use PHPUnit\Framework\TestCase;
+
+final class EnumDescriptionTest extends TestCase
+{
+    public function test_defaults_to_readable_const(): void
+    {
+        $this->assertSame('No description', (new Described(Described::NO_DESCRIPTION))->description);
+    }
+
+    public function test_phpdoc_single_line(): void
+    {
+        $this->assertSame('just one line', (new Described(Described::SINGLE_LINE))->description);
+    }
+
+    public function test_phpdoc_multi_line(): void
+    {
+        $this->assertSame(<<<'PHPDOC'
+more
+than
+one
+line
+PHPDOC
+, (new Described(Described::MULTI_LINE))->description);
+    }
+
+    public function test_phpdoc_deprecated(): void
+    {
+        $this->assertSame('@deprecated because some reason', (new Described(Described::DEPRECATED))->description);
+    }
+}

--- a/tests/EnumInstanceTest.php
+++ b/tests/EnumInstanceTest.php
@@ -55,13 +55,6 @@ class EnumInstanceTest extends TestCase
         $this->assertEquals($userType->key, UserType::getKey(UserType::Administrator));
     }
 
-    public function test_can_get_the_description_for_an_enum_instance()
-    {
-        $userType = UserType::fromValue(UserType::Administrator);
-
-        $this->assertEquals($userType->description, UserType::getDescription(UserType::Administrator));
-    }
-
     public function test_can_get_enum_instance_by_calling_an_enum_key_as_a_static_method()
     {
         $this->assertInstanceOf(UserType::class, UserType::Administrator());

--- a/tests/Enums/Described.php
+++ b/tests/Enums/Described.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace BenSampo\Enum\Tests\Enums;
+
+use BenSampo\Enum\Enum;
+
+final class Described extends Enum
+{
+    const NO_DESCRIPTION = 0;
+
+    /** just one line */
+    const SINGLE_LINE = 1;
+
+    /** more
+     * than
+     * one
+     * line
+     */
+    const MULTI_LINE = 2;
+
+    /**
+     * @deprecated because some reason
+     */
+    const DEPRECATED = 3;
+}

--- a/tests/QueriesFlaggedEnumsTest.php
+++ b/tests/QueriesFlaggedEnumsTest.php
@@ -63,7 +63,7 @@ class QueriesFlaggedEnumsTest extends TestCase
 
     /** @test */
     public function it_can_ensure_any_flag_is_present()
-    {       
+    {
         $this->assertEquals(2, TestModel::query()->hasAnyFlags('superpowers', [SuperPowers::Strength, SuperPowers::Flight])->count());
         $this->assertEquals(1, TestModel::query()->hasAnyFlags('superpowers', [SuperPowers::Invisibility, SuperPowers::Flight])->count());
         $this->assertEquals(2, TestModel::query()->hasAnyFlags('superpowers', [SuperPowers::Immortality])->count());


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Added or updated the [README.md](../README.md)
- [x] Detailed changes in the [CHANGELOG.md](../CHANGELOG.md) unreleased section

**Related Issue/Intent**

I wanted an easier way to add meaningful descriptions to my enum values.

**Changes**

The PHPDoc of an enum value constant is now considered as its description.

**Breaking changes**

Descriptions might change if users already added PHPDocs. Given that descriptions are only meant for display purposes, this should not be a critical change.
