### PR TITLE
Return default when facade is not available for Enum::getDescription

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/BenSampo/laravel-enum/compare/v4.1.0...master)
 
+### Changed
+
+- Catch exception and return default when Lang facade is not available for LocalizedEnum::getDescription
+
 ## [4.1.0](https://github.com/BenSampo/laravel-enum/compare/v4.0.0...v4.1.0) - 2021-11-16
 
 ### Added

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -2,6 +2,7 @@
 
 namespace BenSampo\Enum;
 
+use Exception;
 use ReflectionClass;
 use JsonSerializable;
 use Illuminate\Support\Str;
@@ -365,8 +366,12 @@ abstract class Enum implements EnumContract, Castable, Arrayable, JsonSerializab
         if (static::isLocalizable()) {
             $localizedStringKey = static::getLocalizationKey() . '.' . $value;
 
-            if (Lang::has($localizedStringKey)) {
-                return __($localizedStringKey);
+            try {
+                if (Lang::has($localizedStringKey)) {
+                    return __($localizedStringKey);
+                }
+            } catch (Exception $exception) {
+                return null;
             }
         }
 

--- a/tests/EnumLocalizationUnitTest.php
+++ b/tests/EnumLocalizationUnitTest.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace BenSampo\Enum\Tests;
+
+use BenSampo\Enum\Tests\Enums\UserTypeLocalized;
+use PHPUnit\Framework\TestCase;
+
+class EnumLocalizationUnitTest extends TestCase
+{
+    public function test_enum_get_description_with_localization()
+    {
+        $this->assertSame('Super administrator', UserTypeLocalized::getDescription(UserTypeLocalized::SuperAdministrator));
+    }
+}


### PR DESCRIPTION
- [X] Added or updated tests
- [ ] Added or updated the [README.md](../README.md) (N/A)
- [X] Detailed changes in the [CHANGELOG.md](../CHANGELOG.md) unreleased section

**Related Issue/Intent**

I have unit tests that do not have any application setup and therefore no facades available. Using enum instances in these tests is usually no problem, unless the enum implements `LocalizedEnum`. Then creating an enum instance throws an exception and breaks the test. Even when I'm not interested in a localized value.

**Changes**

Instead of letting the missing facade/translator exception bubble up, let the enum return the default friendly key name.

**Breaking changes**

`Enum::getDescription` will no longer throw an exception for errors during translation when implementing `LocalizedEnum`, but returns `Enum::getFriendlyKeyName` instead.
