### PR TITLE
Fix return type on FlaggedEnum `flags` method

### DIFF
--- a/src/FlaggedEnum.php
+++ b/src/FlaggedEnum.php
@@ -49,7 +49,7 @@ abstract class FlaggedEnum extends Enum
      * Return a FlaggedEnum instance with defined flags.
      *
      * @param  int[]|\BenSampo\Enum\Enum[]  $flags
-     * @return void
+     * @return self
      */
     public static function flags($flags): self
     {


### PR DESCRIPTION
**Changes**
Fix the return type in the phpdoc block on the `flags` method, to match the return type in the signature itself.

**Breaking changes**

