### PR TITLE
Enum description attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/BenSampo/laravel-enum/compare/v5.0.0...master)
 
+### Added
+
+- Ability to define enum case descriptions using `Description` attribute.
+
 ## [5.0.0](https://github.com/BenSampo/laravel-enum/compare/v4.2.0...v5.0.0) - 2022-02-09
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 Simple, extensible and powerful enumeration implementation for Laravel.
 
 - Enum key value pairs as class constants
-- Full featured suite of methods
+- Full-featured suite of methods
 - Enum instantiation
 - Flagged/Bitwise enums
 - Type hinting
@@ -39,7 +39,7 @@ Created by [Ben Sampson](https://sampo.co.uk)
 - [Migrations](#migrations)
 - [Validation](#validation)
 - [Localization](#localization)
-- [Overriding the getDescription method](#overriding-the-getdescription-method)
+- [Customizing descriptions](#customizing-descriptions)
 - [Extending the Enum Base Class](#extending-the-enum-base-class)
 - [Laravel Nova Integration](#laravel-nova-integration)
 - [PHPStan Integration](#phpstan-integration)
@@ -719,7 +719,7 @@ php artisan vendor:publish --provider="BenSampo\Enum\EnumServiceProvider" --tag=
 
 ### Enum descriptions
 
-You can translate the strings returned by the `getDescription` method using Laravel's built in [localization](https://laravel.com/docs/localization) features.
+You can translate the strings returned by the `getDescription` method using Laravel's built-in [localization](https://laravel.com/docs/localization) features.
 
 Add a new `enums.php` keys file for each of your supported languages. In this example there is one for English and one for Spanish.
 
@@ -769,22 +769,26 @@ final class UserType extends Enum implements LocalizedEnum
 
 The `getDescription` method will now look for the value in your localization files. If a value doesn't exist for a given key, the default description is returned instead.
 
-## Overriding the getDescription method
+## Customizing descriptions
 
-If you'd like to return a custom value from the getDescription method, you may do so by overriding the method on your enum:
+If you'd like to return a custom description for your enum values, add a `Description` attribute to your Enum constants:
 
 ```php
-public static function getDescription($value): string
-{
-    if ($value === self::SuperAdministrator) {
-        return 'Super admin';
-    }
+use BenSampo\Enum\Enum;
+use BenSampo\Enum\Attributes\Description;
 
-    return parent::getDescription($value);
+final class UserType extends Enum
+{
+    const Administrator = 'Administrator';
+
+    #[Description('Super admin')]
+    const SuperAdministrator = 'SuperAdministrator';
 }
 ```
 
-Calling `UserType::getDescription(3);` now returns `Super admin` instead of `Super administator`.
+Calling `UserType::SuperAdministrator()->description` now returns `Super admin` instead of `SuperAdministrator`.
+
+You may also override the `getDescription` method on the base Enum class if you wish to have more control of the description.
 
 ## Extending the Enum Base Class
 
@@ -800,7 +804,7 @@ Enum::macro('asFlippedArray', function() {
 
 Now, on each of my enums, I can call it using `UserType::asFlippedArray()`.
 
-It's best to register the macro inside of a service providers' boot method.
+It's best to register the macro inside a service providers' boot method.
 
 ## Laravel Nova Integration
 

--- a/README.md
+++ b/README.md
@@ -786,7 +786,7 @@ final class UserType extends Enum
 }
 ```
 
-Calling `UserType::SuperAdministrator()->description` now returns `Super admin` instead of `SuperAdministrator`.
+Calling `UserType::SuperAdministrator()->description` now returns `Super admin` instead of `Super administrator`.
 
 You may also override the `getDescription` method on the base Enum class if you wish to have more control of the description.
 
@@ -896,7 +896,7 @@ UserType::hasValue('1', false); // Returns 'True'
 
 ### static getDescription(mixed $value): string
 
-Returns the key in sentence case for the enum value. It's possible to [override the getDescription](#overriding-the-getDescription-method) method to return custom descriptions.
+Returns the key in sentence case for the enum value. It's possible to [customize the description](#customizing-descriptions) if the guessed description is not appropriate.
 
 ```php
 UserType::getDescription(3); // Returns 'Super administrator'

--- a/src/Attributes/Description.php
+++ b/src/Attributes/Description.php
@@ -7,10 +7,7 @@ use Attribute;
 #[Attribute(Attribute::TARGET_CLASS_CONSTANT)]
 class Description
 {
-    public string $description;
-
-    public function __construct(string $description)
-    {
-        $this->description = $description;
-    }
+    public function __construct(
+        public string $description,
+    ) {}
 }

--- a/src/Attributes/Description.php
+++ b/src/Attributes/Description.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace BenSampo\Enum\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS_CONSTANT)]
+class Description
+{
+    public string $description;
+
+    public function __construct(string $description)
+    {
+        $this->description = $description;
+    }
+}

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Str;
 use BenSampo\Enum\Casts\EnumCast;
 use Illuminate\Support\Facades\Lang;
 use Illuminate\Support\Traits\Macroable;
+use BenSampo\Enum\Attributes\Description;
 use BenSampo\Enum\Contracts\EnumContract;
 use BenSampo\Enum\Contracts\LocalizedEnum;
 use Illuminate\Contracts\Support\Arrayable;
@@ -348,6 +349,7 @@ abstract class Enum implements EnumContract, Castable, Arrayable, JsonSerializab
     {
         return
             static::getLocalizedDescription($value) ??
+            static::getAttributeDescription($value) ??
             static::getFriendlyKeyName(static::getKey($value));
     }
 
@@ -368,6 +370,28 @@ abstract class Enum implements EnumContract, Castable, Arrayable, JsonSerializab
             if (Lang::has($localizedStringKey)) {
                 return __($localizedStringKey);
             }
+        }
+
+        return null;
+    }
+
+    /**
+     * Get the description of a value from its PHP attribute.
+     *
+     * @param  mixed  $value
+     * @return string|null
+     */
+    protected static function getAttributeDescription($value): ?string
+    {
+        $reflection = new ReflectionClass(static::class);
+        $constantName = static::getKey($value);
+        $constReflection = $reflection->getReflectionConstant($constantName);
+        $descriptionAttributes = $constReflection->getAttributes(Description::class);
+
+        if (count($descriptionAttributes)) {
+            $attribute = $descriptionAttributes[0];
+
+            return $attribute->newInstance()->description;
         }
 
         return null;

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -107,7 +107,7 @@ abstract class Enum implements EnumContract, Castable, Arrayable, JsonSerializab
     {
         $class = static::class;
 
-        return static::$reflectionCache[$class] ??= new ReflectionClass($class));
+        return static::$reflectionCache[$class] ??= new ReflectionClass($class);
     }
 
     /**

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -107,7 +107,7 @@ abstract class Enum implements EnumContract, Castable, Arrayable, JsonSerializab
     {
         $class = static::class;
 
-        return static::$reflectionCache[$class] ??= (static::$reflectionCache[$class] = new ReflectionClass($class));
+        return static::$reflectionCache[$class] ??= new ReflectionClass($class));
     }
 
     /**

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -394,12 +394,12 @@ abstract class Enum implements EnumContract, Castable, Arrayable, JsonSerializab
         $constReflection = $reflection->getReflectionConstant($constantName);
         $descriptionAttributes = $constReflection->getAttributes(Description::class);
 
-        if (count($descriptionAttributes) > 1) {
-            throw new Exception('You cannot use more than 1 description attribute on ' . class_basename(static::class) . '::' . $constantName);
-        }
-
         if (count($descriptionAttributes) === 1) {
             return $descriptionAttributes[0]->newInstance()->description;
+        }
+
+        if (count($descriptionAttributes) > 1) {
+            throw new Exception('You cannot use more than 1 description attribute on ' . class_basename(static::class) . '::' . $constantName);
         }
 
         return null;

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -2,6 +2,7 @@
 
 namespace BenSampo\Enum;
 
+use Exception;
 use ReflectionClass;
 use JsonSerializable;
 use Illuminate\Support\Str;
@@ -393,10 +394,12 @@ abstract class Enum implements EnumContract, Castable, Arrayable, JsonSerializab
         $constReflection = $reflection->getReflectionConstant($constantName);
         $descriptionAttributes = $constReflection->getAttributes(Description::class);
 
-        if (count($descriptionAttributes)) {
-            $attribute = $descriptionAttributes[0];
+        if (count($descriptionAttributes) > 1) {
+            throw new Exception('You cannot use more than 1 description attribute on ' . class_basename(static::class) . '::' . $constantName);
+        }
 
-            return $attribute->newInstance()->description;
+        if (count($descriptionAttributes) === 1) {
+            return $descriptionAttributes[0]->newInstance()->description;
         }
 
         return null;

--- a/tests/EnumAttributeDescriptionTest.php
+++ b/tests/EnumAttributeDescriptionTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace BenSampo\Enum\Tests;
+
+use PHPUnit\Framework\TestCase;
+use BenSampo\Enum\Tests\Enums\DescriptionFromAttribute;
+
+class EnumAttributeDescriptionTest extends TestCase
+{
+    public function test_enum_can_get_description_defined_using_attribute()
+    {
+        $this->assertSame('Admin', DescriptionFromAttribute::getDescription(DescriptionFromAttribute::Administrator));
+        $this->assertSame('Mod (Level 1)', DescriptionFromAttribute::getDescription(DescriptionFromAttribute::Moderator));
+    }
+
+    public function test_enum_description_falls_back_to_get_description_method_when_not_defined_using_attribute()
+    {
+        $this->assertSame('Super Admin', DescriptionFromAttribute::getDescription(DescriptionFromAttribute::SuperAdministrator));
+    }
+}

--- a/tests/EnumAttributeDescriptionTest.php
+++ b/tests/EnumAttributeDescriptionTest.php
@@ -2,6 +2,7 @@
 
 namespace BenSampo\Enum\Tests;
 
+use Exception;
 use PHPUnit\Framework\TestCase;
 use BenSampo\Enum\Tests\Enums\DescriptionFromAttribute;
 
@@ -16,5 +17,12 @@ class EnumAttributeDescriptionTest extends TestCase
     public function test_enum_description_falls_back_to_get_description_method_when_not_defined_using_attribute()
     {
         $this->assertSame('Super Admin', DescriptionFromAttribute::getDescription(DescriptionFromAttribute::SuperAdministrator));
+    }
+
+    public function test_an_exception_is_thrown_when_accessing_a_description_which_is_annotated_with_multiple_description_attributes()
+    {
+        $this->expectException(Exception::class);
+
+        DescriptionFromAttribute::InvalidCaseWithMultipleDescriptions()->description;
     }
 }

--- a/tests/Enums/DescriptionFromAttribute.php
+++ b/tests/Enums/DescriptionFromAttribute.php
@@ -17,6 +17,10 @@ final class DescriptionFromAttribute extends Enum
 
     const SuperAdministrator = 3;
 
+    #[Description('First description')]
+    #[Description('Second description')]
+    const InvalidCaseWithMultipleDescriptions = 4;
+
     public static function getDescription($value): string
     {
         if ($value === self::SuperAdministrator) {

--- a/tests/Enums/DescriptionFromAttribute.php
+++ b/tests/Enums/DescriptionFromAttribute.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace BenSampo\Enum\Tests\Enums;
+
+use BenSampo\Enum\Enum;
+use BenSampo\Enum\Attributes\Description;
+
+final class DescriptionFromAttribute extends Enum
+{
+    #[Description('Admin')]
+    const Administrator = 0;
+
+    #[Description('Mod (Level 1)')]
+    const Moderator = 1;
+
+    const Subscriber = 2;
+
+    const SuperAdministrator = 3;
+
+    public static function getDescription($value): string
+    {
+        if ($value === self::SuperAdministrator) {
+            return 'Super Admin';
+        }
+
+        return parent::getDescription($value);
+    }
+}


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Added or updated the [README.md](../README.md)
- [x] Detailed changes in the [CHANGELOG.md](../CHANGELOG.md) unreleased section

**Related Issue/Intent**

Make it easier to define descriptions for each enum case.

**Changes**

I've added the ability to add descriptions to each enum case using a PHP8 attribute. This is favoured over defining them in the getDescription method because each description remains close to the case it's describing. It's also easier to see which cases have descriptions and which don't.

```php
final class UserType extends Enum
{
    #[Description('Admin')]
    const Administrator = 0;

    #[Description('Super admin')]
    const SuperAdministrator = 1;
}
```

@spawnia This is inspired by [your PR](https://github.com/BenSampo/laravel-enum/pull/239). I was slightly uncomfortable with defining the descriptions using docblocks and since I've updated the packages' min PHP support to 8.0 (because of L9) I thought this would be a good opportunity to use some of those new features. I would appreciate your review on this if you have time.

**Breaking changes**

None
