### PR TITLE
Restore enum instance from `var_export()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/BenSampo/laravel-enum/compare/v5.1.0...master)
 
+### Added
+
+- Restore enum instance from `var_export()`
+
 ## [5.1.0](https://github.com/BenSampo/laravel-enum/compare/v5.0.0...v5.1.0) - 2022-02-09
 
 ### Added

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -72,6 +72,17 @@ abstract class Enum implements EnumContract, Castable, Arrayable, JsonSerializab
     }
 
     /**
+     * Restores an enum instance exported by var_export().
+     *
+     * @param  array{value: mixed, key: string, description: string}  $enum
+     * @return static
+     */
+    public static function __set_state(array $enum): static
+    {
+        return new static($enum['value']);
+    }
+
+    /**
      * Make a new instance from an enum value.
      *
      * @param  mixed  $enumValue

--- a/tests/VarExportTest.php
+++ b/tests/VarExportTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace BenSampo\Enum\Tests;
+
+use PHPUnit\Framework\TestCase;
+use BenSampo\Enum\Tests\Enums\UserType;
+
+class VarExportTest extends TestCase
+{
+    public function test_var_export()
+    {
+        $admin = UserType::Administrator();
+
+        $exported = var_export($admin, true);
+        $restored = eval("return {$exported};");
+
+        $this->assertSame($admin->value, $restored->value);
+    }
+}


### PR DESCRIPTION
- [x] Added or updated tests
- ~[ ] Added or updated the [README.md](../README.md)~
- [x] Detailed changes in the [CHANGELOG.md](../CHANGELOG.md) unreleased section

**Related Issue/Intent**

Resolves https://github.com/BenSampo/laravel-enum/issues/251

**Changes**

Restore enum instance from `var_export()`.

**Breaking changes**

None, this just did not work before.