### PR TITLE
Fix getAttributeDescription() error

### DIFF
--- a/src/Enum.php
+++ b/src/Enum.php
@@ -403,6 +403,9 @@ abstract class Enum implements EnumContract, Castable, Arrayable, JsonSerializab
         $reflection = self::getReflection();
         $constantName = static::getKey($value);
         $constReflection = $reflection->getReflectionConstant($constantName);
+        if ($constReflection === false) {
+            return null;
+        }
         $descriptionAttributes = $constReflection->getAttributes(Description::class);
 
         if (count($descriptionAttributes) === 1) {

--- a/tests/EnumAttributeDescriptionTest.php
+++ b/tests/EnumAttributeDescriptionTest.php
@@ -25,4 +25,9 @@ class EnumAttributeDescriptionTest extends TestCase
 
         DescriptionFromAttribute::InvalidCaseWithMultipleDescriptions()->description;
     }
+
+    public function test_an_exception_is_not_thrown_when_accessing_a_description_for_an_invalid_value()
+    {
+        $this->assertSame('', DescriptionFromAttribute::getDescription('invalid'));
+    }
 }


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] Added or updated the [README.md](../README.md)
- [ ] Detailed changes in the [CHANGELOG.md](../CHANGELOG.md) unreleased section

**Related Issue/Intent**
Resolves #263

**Changes**
Calling `MyEnum::getDescription($value)` with an invalid value now returns an empty string, rather than throwing an error. This is in line with the behaviour in v4.

**Breaking changes**
N/A
