### PR TITLE
Require composer/class-map-generator over composer/composer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/BenSampo/laravel-enum/compare/v5.3.0...master)
 
+### Changed
+
+- Require composer/class-map-generator over composer/composer [268](https://github.com/BenSampo/laravel-enum/pull/268)
+
 ## [5.3.1](https://github.com/BenSampo/laravel-enum/compare/v5.3.0...v5.3.1) - 2022-06-22
 
 ### Fixed

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "homepage": "https://github.com/bensampo/laravel-enum",
     "require": {
         "php": "^8",
-        "composer/composer": "^2.2",
+        "composer/class-map-generator": "^1",
         "illuminate/contracts": "^9",
         "illuminate/support": "^9",
         "laminas/laminas-code": "^3.4 || ^4",

--- a/src/Commands/AbstractAnnotationCommand.php
+++ b/src/Commands/AbstractAnnotationCommand.php
@@ -7,7 +7,7 @@ use ReflectionClass;
 use InvalidArgumentException;
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
-use Composer\Autoload\ClassMapGenerator;
+use Composer\ClassMapGenerator\ClassMapGenerator;
 use Laminas\Code\Generator\DocBlockGenerator;
 use Laminas\Code\Reflection\DocBlockReflection;
 use Symfony\Component\Console\Input\InputOption;
@@ -73,7 +73,7 @@ abstract class AbstractAnnotationCommand extends Command
     protected function annotateFolder()
     {
         $classMap = ClassMapGenerator::createMap($this->searchDirectory());
-        
+
         /** @var \ReflectionClass[] $classes */
         $classes = array_map(function ($class) {
             return new ReflectionClass($class);


### PR DESCRIPTION
- [x] Added or updated tests
- [ ] ~Added or updated the [README.md](../README.md)~
- [x] Detailed changes in the [CHANGELOG.md](../CHANGELOG.md) unreleased section

**Related Issue/Intent**

Resolves https://github.com/BenSampo/laravel-enum/issues/249

**Changes**

Require composer/class-map-generator over composer/composer.

**Breaking changes**

Functionality stays the same, but I consider a new dependency a breaking change.