### PR TITLE
Allow Description attribute on class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Require composer/class-map-generator over composer/composer [268](https://github.com/BenSampo/laravel-enum/pull/268)
+- Allow Description attribute usage on class [270](https://github.com/BenSampo/laravel-enum/pull/270)
 
 ## [5.3.1](https://github.com/BenSampo/laravel-enum/compare/v5.3.0...v5.3.1) - 2022-06-22
 

--- a/README.md
+++ b/README.md
@@ -769,7 +769,26 @@ final class UserType extends Enum implements LocalizedEnum
 
 The `getDescription` method will now look for the value in your localization files. If a value doesn't exist for a given key, the default description is returned instead.
 
-## Customizing descriptions
+## Customizing enum class description
+
+If you'd like to return a custom description for your enum class, add a `Description` attribute to your Enum class:
+
+```php
+use BenSampo\Enum\Enum;
+use BenSampo\Enum\Attributes\Description;
+
+#[Description('List of available User types')]
+final class UserType extends Enum
+{
+    ...
+}
+```
+
+Calling `UserType::getClassDescription()` now returns `List of available User types` instead of `User type`.
+
+You may also override the `getClassDescription` method on the base Enum class if you wish to have more control of the description.
+
+## Customizing value descriptions
 
 If you'd like to return a custom description for your enum values, add a `Description` attribute to your Enum constants:
 
@@ -892,6 +911,14 @@ UserType::hasValue(1); // Returns 'True'
 // It's possible to disable the strict type checking:
 UserType::hasValue('1'); // Returns 'False'
 UserType::hasValue('1', false); // Returns 'True'
+```
+
+### static getClassDescription(): string
+
+Returns the class name in sentence case for the enum class. It's possible to [customize the description](#customizing-descriptions) if the guessed description is not appropriate.
+
+```php
+UserType::getClassDescription(); // Returns 'User type'
 ```
 
 ### static getDescription(mixed $value): string

--- a/src/Attributes/Description.php
+++ b/src/Attributes/Description.php
@@ -4,7 +4,7 @@ namespace BenSampo\Enum\Attributes;
 
 use Attribute;
 
-#[Attribute(Attribute::TARGET_CLASS_CONSTANT)]
+#[Attribute(Attribute::TARGET_CLASS_CONSTANT | Attribute::TARGET_CLASS)]
 class Description
 {
     public function __construct(

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -367,7 +367,7 @@ abstract class Enum implements EnumContract, Castable, Arrayable, JsonSerializab
         return
             static::getLocalizedDescription($value) ??
             static::getAttributeDescription($value) ??
-            static::getFriendlyKeyName(static::getKey($value));
+            static::getFriendlyName(static::getKey($value));
     }
 
     /**
@@ -414,6 +414,36 @@ abstract class Enum implements EnumContract, Castable, Arrayable, JsonSerializab
 
         if (count($descriptionAttributes) > 1) {
             throw new Exception('You cannot use more than 1 description attribute on ' . class_basename(static::class) . '::' . $constantName);
+        }
+
+        return null;
+    }
+
+    /**
+     * Get the description of the enum class.
+     * Default to Enum class short name
+     *
+     * @return string
+     * @throws Exception
+     */
+    public static function getClassDescription(): string
+    {
+        return static::getClassAttributeDescription()
+            ?? static::getFriendlyName(self::getReflection()->getShortName());
+    }
+
+    protected static function getClassAttributeDescription(): ?string
+    {
+        $reflection = self::getReflection();
+
+        $descriptionAttributes = $reflection->getAttributes(Description::class);
+
+        if (count($descriptionAttributes) === 1) {
+            return $descriptionAttributes[0]->newInstance()->description;
+        }
+
+        if (count($descriptionAttributes) > 1) {
+            throw new Exception('You cannot use more than 1 description attribute on '.class_basename(static::class));
         }
 
         return null;
@@ -520,12 +550,13 @@ abstract class Enum implements EnumContract, Castable, Arrayable, JsonSerializab
     }
 
     /**
-     * Transform the key name into a friendly, formatted version.
+     * Transform the name into a friendly, formatted version.
      *
      * @param  string  $key
+     *
      * @return string
      */
-    protected static function getFriendlyKeyName(string $key): string
+    protected static function getFriendlyName(string $key): string
     {
         if (ctype_upper(preg_replace('/[^a-zA-Z]/', '', $key))) {
             $key = strtolower($key);

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -424,7 +424,6 @@ abstract class Enum implements EnumContract, Castable, Arrayable, JsonSerializab
      * Default to Enum class short name
      *
      * @return string
-     * @throws Exception
      */
     public static function getClassDescription(): string
     {
@@ -432,9 +431,6 @@ abstract class Enum implements EnumContract, Castable, Arrayable, JsonSerializab
             ?? static::getFriendlyName(self::getReflection()->getShortName());
     }
 
-    /**
-     * @throws \Exception
-     */
     protected static function getClassAttributeDescription(): ?string
     {
         $reflection = self::getReflection();
@@ -444,9 +440,7 @@ abstract class Enum implements EnumContract, Castable, Arrayable, JsonSerializab
         return match (count($descriptionAttributes)) {
             0 => null,
             1 => $descriptionAttributes[0]->newInstance()->description,
-            default => throw new Exception(
-                'You cannot use more than 1 description attribute on '.class_basename(static::class)
-            )
+            default => throw new Exception('You cannot use more than 1 description attribute on '.class_basename(static::class))
         };
     }
 

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -432,21 +432,22 @@ abstract class Enum implements EnumContract, Castable, Arrayable, JsonSerializab
             ?? static::getFriendlyName(self::getReflection()->getShortName());
     }
 
+    /**
+     * @throws \Exception
+     */
     protected static function getClassAttributeDescription(): ?string
     {
         $reflection = self::getReflection();
 
         $descriptionAttributes = $reflection->getAttributes(Description::class);
 
-        if (count($descriptionAttributes) === 1) {
-            return $descriptionAttributes[0]->newInstance()->description;
-        }
-
-        if (count($descriptionAttributes) > 1) {
-            throw new Exception('You cannot use more than 1 description attribute on '.class_basename(static::class));
-        }
-
-        return null;
+        return match (count($descriptionAttributes)) {
+            0 => null,
+            1 => $descriptionAttributes[0]->newInstance()->description,
+            default => throw new Exception(
+                'You cannot use more than 1 description attribute on '.class_basename(static::class)
+            )
+        };
     }
 
     /**
@@ -552,17 +553,17 @@ abstract class Enum implements EnumContract, Castable, Arrayable, JsonSerializab
     /**
      * Transform the name into a friendly, formatted version.
      *
-     * @param  string  $key
+     * @param  string  $name
      *
      * @return string
      */
-    protected static function getFriendlyName(string $key): string
+    protected static function getFriendlyName(string $name): string
     {
-        if (ctype_upper(preg_replace('/[^a-zA-Z]/', '', $key))) {
-            $key = strtolower($key);
+        if (ctype_upper(preg_replace('/[^a-zA-Z]/', '', $name))) {
+            $name = strtolower($name);
         }
 
-        return ucfirst(str_replace('_', ' ', Str::snake($key)));
+        return ucfirst(str_replace('_', ' ', Str::snake($name)));
     }
 
     /**

--- a/tests/EnumAttributeDescriptionTest.php
+++ b/tests/EnumAttributeDescriptionTest.php
@@ -2,13 +2,26 @@
 
 namespace BenSampo\Enum\Tests;
 
+use BenSampo\Enum\Tests\Enums\InvalidMultipleClassDescriptionFromAttribute;
 use Exception;
 use PHPUnit\Framework\TestCase;
 use BenSampo\Enum\Tests\Enums\DescriptionFromAttribute;
 
 class EnumAttributeDescriptionTest extends TestCase
 {
-    public function test_enum_can_get_description_defined_using_attribute()
+    public function test_enum_can_get_class_description_defined_using_attribute()
+    {
+        $this->assertSame('Enum description', DescriptionFromAttribute::getClassDescription());
+    }
+
+    public function test_an_exception_is_thrown_when_accessing_a_class_description_which_is_annotated_with_multiple_description_attributes()
+    {
+        $this->expectException(Exception::class);
+
+        InvalidMultipleClassDescriptionFromAttribute::getClassDescription();
+    }
+
+    public function test_enum_can_get_value_description_defined_using_attribute()
     {
         $this->assertSame('Admin', DescriptionFromAttribute::getDescription(DescriptionFromAttribute::Administrator));
         $this->assertSame('Mod (Level 1)', DescriptionFromAttribute::getDescription(DescriptionFromAttribute::Moderator));

--- a/tests/EnumTest.php
+++ b/tests/EnumTest.php
@@ -124,6 +124,11 @@ class EnumTest extends TestCase
         $this->assertSame('Lowercase snake case numeric suffix 2', MixedKeyFormats::getDescription(MixedKeyFormats::lowercase_snake_case_numeric_suffix_2));
     }
 
+    public function test_enum_get_class_description()
+    {
+        $this->assertSame('Mixed key formats', MixedKeyFormats::getClassDescription());
+    }
+
     public function test_enum_get_random_key()
     {
         $this->assertContains(UserType::getRandomKey(), UserType::getKeys());

--- a/tests/Enums/DescriptionFromAttribute.php
+++ b/tests/Enums/DescriptionFromAttribute.php
@@ -5,6 +5,7 @@ namespace BenSampo\Enum\Tests\Enums;
 use BenSampo\Enum\Enum;
 use BenSampo\Enum\Attributes\Description;
 
+#[Description('Enum description')]
 final class DescriptionFromAttribute extends Enum
 {
     #[Description('Admin')]

--- a/tests/Enums/InvalidMultipleClassDescriptionFromAttribute.php
+++ b/tests/Enums/InvalidMultipleClassDescriptionFromAttribute.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace BenSampo\Enum\Tests\Enums;
+
+use BenSampo\Enum\Enum;
+use BenSampo\Enum\Attributes\Description;
+
+#[Description('First Enum description')]
+// @phpstan-ignore-next-line intentionally wrong
+#[Description('Second Enum description')]
+final class InvalidMultipleClassDescriptionFromAttribute extends Enum
+{
+    const Administrator = 0;
+
+    const Moderator = 1;
+}


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Added or updated the [README.md](../README.md)
- [x] Detailed changes in the [CHANGELOG.md](../CHANGELOG.md) unreleased section

**Related Issue/Intent**

We are working with this package alongside [Lighthouse](https://github.com/nuwave/lighthouse). 
As an updated our GQL standards we realized auto generated GQL enums from BenShampo\Enum does not generate a description for the enum, only its values.

This PR propose broadening the usage of the Description attribute, so that it may be used on the Enum class itself.

Next step will be to update the [LaravelEnumType](https://github.com/nuwave/lighthouse/blob/master/src/Schema/Types/LaravelEnumType.php) from Lighthouse to include the description on the generated enum 😄 

**Changes**

* introduce new usage of Description attribute at class level
* add new static method getClassDescription() on Enum
* test new method getClassDescription()

**Breaking changes**

Nope.
