### PR TITLE
allow non-empty-string in hasValue

### DIFF
--- a/src/Enum.php
+++ b/src/Enum.php
@@ -476,8 +476,6 @@ abstract class Enum implements EnumContract, Castable, Arrayable, JsonSerializab
 
     /**
      * Check that the enum contains a specific value.
-     *
-     * @param  TValue|non-empty-string  $value
      */
     public static function hasValue(mixed $value, bool $strict = true): bool
     {

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -477,7 +477,7 @@ abstract class Enum implements EnumContract, Castable, Arrayable, JsonSerializab
     /**
      * Check that the enum contains a specific value.
      *
-     * @param  TValue  $value
+     * @param  TValue|non-empty-string  $value
      */
     public static function hasValue(mixed $value, bool $strict = true): bool
     {


### PR DESCRIPTION
- [ ] Added or updated tests
- [ ] Added or updated the [README.md](../README.md)
- [ ] Detailed changes in the [CHANGELOG.md](../CHANGELOG.md) unreleased section

**Changes**

I believe that hasValue should also accept non-empty-string, not only TValue, because if I use enum like this:

```
<?php
namespace App\Enum;

use BenSampo\Enum\Enum;

/**
 * @extends Enum<self::*>
 */
class MyEnum extends Enum
{
    public const TEST = 'test';
}
?>
```

then static analysis does not allow me to pass any other value to than 'test' to hasValue method, which is wrong, because if I already know that its there, I dont need to call hasValue()