### PR TITLE
Prevent translations to be discarded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add command `enum:to-native` to convert a class that extends `BenSampo\Enum\Enum` to a native PHP enum
 
+### Fixed
+
+- Prevent translations to be discarded [324](https://github.com/BenSampo/laravel-enum/pull/324)
+
 ## 6.3.3
 
 ### Fixed


### PR DESCRIPTION
- [ ] Added or updated tests
- [ ] Added or updated the [README.md](../README.md)
- [x] Detailed changes in the [CHANGELOG.md](../CHANGELOG.md) unreleased section

**Related Issue**
When the boot method is loaded before third-party translation paths, the __() function calls to trigger the preload of all available translations in the global domain (JSON translation files). As a result, any json path registered later is ignored, leading to the discarding of all their translations.

**Changes**
Ensure that the `ValidationFactory` is fully initialized before creating an instance, guaranteeing that the boot process is complete. 
