### PR TITLE
Add PHPStan rule to detect duplicate enum values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 6.7.0
+
+### Added
+
+- Add PHPStan rule to detect duplicate enum values
+
 ## 6.6.4
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -859,11 +859,11 @@ Use the [nova-enum-field](https://github.com/simplesquid/nova-enum-field) packag
 
 ## PHPStan Integration
 
-If you are using [PHPStan](https://github.com/phpstan/phpstan) for static
-analysis, you can enable the extension for proper recognition of the
-magic instantiation methods.
+If you are using [PHPStan](https://github.com/phpstan/phpstan) for static analysis, enable the extension for:
+- proper recognition of the magic instantiation methods
+- detection of duplicate enum values
 
-Add the following to your projects `phpstan.neon` includes:
+Use [PHPStan Extension Installer](https://github.com/phpstan/extension-installer) or add the following to your projects `phpstan.neon` includes:
 
 ```neon
 includes:

--- a/extension.neon
+++ b/extension.neon
@@ -1,4 +1,7 @@
 services:
-- class: \BenSampo\Enum\PHPStan\EnumMethodsClassReflectionExtension
+- class: BenSampo\Enum\PHPStan\EnumMethodsClassReflectionExtension
   tags:
   - phpstan.broker.methodsClassReflectionExtension
+- class: BenSampo\Enum\PHPStan\UniqueValuesRule
+  tags:
+  - phpstan.rules.rule

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -21,6 +21,7 @@ parameters:
   - '#invalid type Illuminate\\Process#'
   excludePaths:
   - tests/Enums/ToNativeFixtures # Fails with PHP < 8.1
+  - tests/PHPStan/Fixtures
   # Install https://plugins.jetbrains.com/plugin/7677-awesome-console to make those links clickable
   editorUrl: '%%relFile%%:%%line%%'
   editorUrlTitle: '%%relFile%%:%%line%%'

--- a/src/PHPStan/UniqueValuesRule.php
+++ b/src/PHPStan/UniqueValuesRule.php
@@ -31,9 +31,18 @@ final class UniqueValuesRule implements Rule
             $constants[$constant->name] = $constant->getValue();
         }
 
-        if (count($constants) !== count(array_unique($constants))) {
+        $duplicateConstants = [];
+        foreach ($constants as $name => $value) {
+            $constantsWithValue = array_filter($constants, fn (mixed $v): bool => $v === $value);
+            if (count($constantsWithValue) > 1) {
+                $duplicateConstants []= array_keys($constantsWithValue);
+            }
+        }
+        $duplicateConstants = array_unique($duplicateConstants);
+
+        if (count($duplicateConstants) > 0) {
             $fqcn = $reflection->getName();
-            $constantsString = json_encode($constants);
+            $constantsString = json_encode($duplicateConstants);
 
             return [
                 RuleErrorBuilder::message("Enum class {$fqcn} contains constants with duplicate values: {$constantsString}.")

--- a/src/PHPStan/UniqueValuesRule.php
+++ b/src/PHPStan/UniqueValuesRule.php
@@ -1,0 +1,46 @@
+<?php declare(strict_types=1);
+
+namespace BenSampo\Enum\PHPStan;
+
+use BenSampo\Enum\Enum;
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Node\InClassNode;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/** @implements Rule<InClassNode> */
+final class UniqueValuesRule implements Rule
+{
+    public function getNodeType(): string
+    {
+        return InClassNode::class;
+    }
+
+    public function processNode(Node $node, Scope $scope): array
+    {
+        assert($node instanceof InClassNode);
+
+        $reflection = $node->getClassReflection();
+        if (! $reflection->isSubclassOf(Enum::class)) {
+            return [];
+        }
+
+        $constants = [];
+        foreach ($reflection->getNativeReflection()->getReflectionConstants() as $constant) {
+            $constants[$constant->name] = $constant->getValue();
+        }
+
+        if (count($constants) !== count(array_unique($constants))) {
+            $fqcn = $reflection->getName();
+            $constantsString = json_encode($constants);
+
+            return [
+                RuleErrorBuilder::message("Enum class {$fqcn} contains constants with duplicate values: {$constantsString}.")
+                    ->build(),
+            ];
+        }
+
+        return [];
+    }
+}

--- a/tests/PHPStan/EnumMethodsClassReflectionExtensionTest.php
+++ b/tests/PHPStan/EnumMethodsClassReflectionExtensionTest.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace BenSampo\Enum\Tests;
+namespace BenSampo\Enum\Tests\PHPStan;
 
 use BenSampo\Enum\PHPStan\EnumMethodsClassReflectionExtension;
 use BenSampo\Enum\Tests\Enums\AnnotatedConstants;
@@ -9,7 +9,7 @@ use PHPStan\Reflection\ClassReflection as PHPStanClassReflection;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Testing\PHPStanTestCase;
 
-final class PHPStanTest extends PHPStanTestCase
+final class EnumMethodsClassReflectionExtensionTest extends PHPStanTestCase
 {
     private EnumMethodsClassReflectionExtension $reflectionExtension;
 

--- a/tests/PHPStan/Fixtures/DuplicateValue.php
+++ b/tests/PHPStan/Fixtures/DuplicateValue.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types=1);
+
+namespace BenSampo\Enum\Tests\PHPStan\Fixtures;
+
+use BenSampo\Enum\Enum;
+
+/**
+ * @extends Enum<string>
+ *
+ * @method static static A()
+ * @method static static B()
+ */
+final class DuplicateValue extends Enum
+{
+    public const A = 'A';
+    public const B = 'A';
+}

--- a/tests/PHPStan/UniqueValuesRuleTest.php
+++ b/tests/PHPStan/UniqueValuesRuleTest.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types=1);
+
+namespace BenSampo\Enum\Tests\PHPStan;
+
+use BenSampo\Enum\PHPStan\UniqueValuesRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/** @extends RuleTestCase<UniqueValuesRule> */
+final class UniqueValuesRuleTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new UniqueValuesRule();
+    }
+
+    public function testRule(): void
+    {
+        $this->analyse(
+            [
+                __DIR__ . '/Fixtures/DuplicateValue.php',
+            ],
+            [
+                [
+                    'Enum class BenSampo\Enum\Tests\PHPStan\Fixtures\DuplicateValue contains constants with duplicate values: {"A":"A","B":"A"}.',
+                    13,
+                ],
+            ],
+        );
+    }
+}

--- a/tests/PHPStan/UniqueValuesRuleTest.php
+++ b/tests/PHPStan/UniqueValuesRuleTest.php
@@ -22,7 +22,7 @@ final class UniqueValuesRuleTest extends RuleTestCase
             ],
             [
                 [
-                    'Enum class BenSampo\Enum\Tests\PHPStan\Fixtures\DuplicateValue contains constants with duplicate values: {"A":"A","B":"A"}.',
+                    'Enum class BenSampo\Enum\Tests\PHPStan\Fixtures\DuplicateValue contains constants with duplicate values: [["A","B"]].',
                     13,
                 ],
             ],


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Added or updated the [README.md](../README.md)
- [x] Detailed changes in the [CHANGELOG.md](../CHANGELOG.md) unreleased section

**Related Issue/Intent**

Duplicate enum values lead to runtime errors, e.g. `getInstances()`.

**Changes**

Adds a PHPStan rule that detects duplicate enum values.

**Breaking changes**

None.
