### PR TITLE
Fix conversion of `in()` and `notIn()` to native enums when called with non-arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 6.11.1
+
+### Fixed
+
+- Fix conversion of `in()` and `notIn()` to native enums when called with non-arrays
+
 ## 6.11.0
 
 ### Added

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -14,6 +14,7 @@ parameters:
   - '#unknown class Illuminate\\Support\\Facades\\Process#'
   - '#unknown class Illuminate\\Process#'
   - '#invalid type Illuminate\\Process#'
+  - '#^Attribute class PHPUnit\\Framework\\Attributes\\DataProvider does not exist\.$#' # Only available with newer PHPUnit versions
   excludePaths:
   - tests/Enums/ToNativeFixtures # Fails with PHP < 8.1
   - tests/PHPStan/Fixtures

--- a/src/Rector/ToNativeUsagesRector.php
+++ b/src/Rector/ToNativeUsagesRector.php
@@ -5,6 +5,7 @@ namespace BenSampo\Enum\Rector;
 use BenSampo\Enum\Enum;
 use BenSampo\Enum\Tests\Enums\UserType;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Enumerable;
 use PhpParser\Node;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr;
@@ -565,7 +566,9 @@ CODE_SAMPLE,
      */
     protected function refactorIsOrIsNot(MethodCall|NullsafeMethodCall $call, bool $is): ?Node
     {
-        $comparison = $is ? Identical::class : NotIdentical::class;
+        $comparison = $is
+            ? Identical::class
+            : NotIdentical::class;
 
         if ($call->isFirstClassCallable()) {
             $param = new Variable('value');
@@ -601,19 +604,38 @@ CODE_SAMPLE,
     {
         $args = $call->args;
         if (isset($args[0]) && $args[0] instanceof Arg) {
-            $needle = new Arg($call->var);
-            $haystack = $args[0];
+            $enumArg = new Arg($call->var);
+            $valuesArg = $args[0];
 
-            $haystackValue = $haystack->value;
-            if ($haystackValue instanceof Array_) {
-                foreach ($haystackValue->items as $item) {
+            $valuesValue = $valuesArg->value;
+            if ($valuesValue instanceof Array_) {
+                foreach ($valuesValue->items as $item) {
                     $item->setAttribute(self::COMPARED_AGAINST_ENUM_INSTANCE, true);
                 }
             }
 
+            if ($this->isObjectType($valuesValue, new ObjectType(Enumerable::class))) {
+                return new MethodCall(
+                    $valuesValue,
+                    new Identifier($in
+                        ? 'contains'
+                        : 'doesntContain'),
+                    [$enumArg],
+                );
+            }
+
+            $haystackArg = $this->getType($valuesValue)->isArray()->yes()
+                ? $valuesArg
+                : new Arg(
+                    new FuncCall(
+                        new Name('iterator_to_array'),
+                        [$valuesArg],
+                    ),
+                );
+
             $inArray = new FuncCall(
                 new Name('in_array'),
-                [$needle, $haystack],
+                [$enumArg, $haystackArg],
                 [self::COMPARED_AGAINST_ENUM_INSTANCE => true],
             );
 

--- a/tests/EnumAnnotateCommandTest.php
+++ b/tests/EnumAnnotateCommandTest.php
@@ -3,10 +3,12 @@
 namespace BenSampo\Enum\Tests;
 
 use Illuminate\Filesystem\Filesystem;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 final class EnumAnnotateCommandTest extends ApplicationTestCase
 {
     /** @dataProvider classes */
+    #[DataProvider('classes')]
     public function testAnnotateClass(string $class): void
     {
         $filesystem = $this->filesystem();
@@ -19,6 +21,7 @@ final class EnumAnnotateCommandTest extends ApplicationTestCase
     }
 
     /** @dataProvider classes */
+    #[DataProvider('classes')]
     public function testAnnotateClassAlreadyAnnotated(string $class): void
     {
         $filesystem = $this->filesystem();
@@ -48,6 +51,7 @@ final class EnumAnnotateCommandTest extends ApplicationTestCase
     }
 
     /** @dataProvider sources */
+    #[DataProvider('sources')]
     public function testAnnotateFolder(string $source): void
     {
         $filesystem = $this->filesystem();

--- a/tests/PHPStan/UniqueValuesRuleTest.php
+++ b/tests/PHPStan/UniqueValuesRuleTest.php
@@ -28,4 +28,9 @@ final class UniqueValuesRuleTest extends RuleTestCase
             ],
         );
     }
+
+    protected function shouldFailOnPhpErrors(): bool
+    {
+        return false;
+    }
 }

--- a/tests/Rector/ToNativeImplementationRectorTest.php
+++ b/tests/Rector/ToNativeImplementationRectorTest.php
@@ -2,12 +2,14 @@
 
 namespace BenSampo\Enum\Tests\Rector;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
 
 /** @see \BenSampo\Enum\Rector\ToNativeImplementationRector */
 final class ToNativeImplementationRectorTest extends AbstractRectorTestCase
 {
     /** @dataProvider provideData */
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);

--- a/tests/Rector/ToNativeUsagesRectorTest.php
+++ b/tests/Rector/ToNativeUsagesRectorTest.php
@@ -2,12 +2,14 @@
 
 namespace BenSampo\Enum\Tests\Rector;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
 
 /** @see \BenSampo\Enum\Rector\ToNativeUsagesRector */
 final class ToNativeUsagesRectorTest extends AbstractRectorTestCase
 {
     /** @dataProvider provideData */
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);

--- a/tests/Rector/Usages/in.php.inc
+++ b/tests/Rector/Usages/in.php.inc
@@ -5,6 +5,10 @@ use BenSampo\Enum\Tests\Enums\UserType;
 /** @var UserType $userType */
 $userType->in([UserType::Administrator, UserType::Subscriber(), null]);
 $userType?->in([UserType::Administrator, $userType, null]);
+/** @var iterable<UserType> $iterable */
+$userType->in($iterable);
+/** @var \Illuminate\Support\Collection $collection */
+$userType->in($collection);
 -----
 <?php
 
@@ -13,3 +17,7 @@ use BenSampo\Enum\Tests\Enums\UserType;
 /** @var UserType $userType */
 in_array($userType, [UserType::Administrator, UserType::Subscriber, null]);
 in_array($userType, [UserType::Administrator, $userType, null]);
+/** @var iterable<UserType> $iterable */
+in_array($userType, iterator_to_array($iterable));
+/** @var \Illuminate\Support\Collection $collection */
+$collection->contains($userType);

--- a/tests/Rector/Usages/notIn.php.inc
+++ b/tests/Rector/Usages/notIn.php.inc
@@ -5,6 +5,10 @@ use BenSampo\Enum\Tests\Enums\UserType;
 /** @var UserType $userType */
 $userType->notIn([UserType::Administrator]);
 $userType?->notIn([UserType::Administrator, $userType]);
+/** @var iterable<UserType> $userTypes */
+$userType->notIn($userTypes);
+/** @var \Illuminate\Support\Collection $collection */
+$userType->notIn($collection);
 -----
 <?php
 
@@ -13,3 +17,7 @@ use BenSampo\Enum\Tests\Enums\UserType;
 /** @var UserType $userType */
 !in_array($userType, [UserType::Administrator]);
 !in_array($userType, [UserType::Administrator, $userType]);
+/** @var iterable<UserType> $userTypes */
+!in_array($userType, iterator_to_array($userTypes));
+/** @var \Illuminate\Support\Collection $collection */
+$collection->doesntContain($userType);


### PR DESCRIPTION
- [x] Added or updated tests
- [x] Added or updated the [README.md](../README.md)
- [x] Detailed changes in the [CHANGELOG.md](../CHANGELOG.md) unreleased section

**Related Issue/Intent**

![image](https://github.com/user-attachments/assets/8cfaca9b-5424-4925-b22a-5af9dca4ea90)

**Changes**

Converts the values given to `in()` or `notIn()` using `iterator_to_array()` if they are not surely an `array` before passing them into `in_array()`.

**Breaking changes**

None.